### PR TITLE
catch errors in jedi#show_func_def()

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -61,7 +61,13 @@ endfunction
 " func_def
 " ------------------------------------------------------------------------
 function jedi#show_func_def()
-    python show_func_def(get_script().get_in_function_call())
+  python << PYTHONEOF
+if 1:
+    try:
+        show_func_def(get_script().get_in_function_call())
+    except Exception as e:
+        print e
+PYTHONEOF
     return ''
 endfunction
 


### PR DESCRIPTION
Screen-filling exceptions on every keystroke are pretty unsatisfying ;) I prefer/recommend catching all exceptions in every python-calling vim function.
I sometimes get a "strange import" error from most of the functions.
