### PR TITLE
remove func_def escape sequence from search history

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -81,6 +81,8 @@ if 1:
     vim.command(r'try | %%s/%s/\1/g | catch | endtry' % regex)
     vim.current.window.cursor = cursor
 PYTHONEOF
+    call histdel("search", -1)
+    let @/ = histget("search", -1)
 endfunction
 
 


### PR DESCRIPTION
When clearing the function signature, `:substitute` adds the escape sequence to the search history. This removes the pattern and resets the last pattern register.
