### PR TITLE
don't set switchbuf option until python filetype is loaded.

### DIFF
--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -45,7 +45,6 @@ if g:jedi#auto_initialization
     " autocompletion as a default, which may cause problems, depending on the
     " order of invocation.
     autocmd FileType python setlocal omnifunc=jedi#complete switchbuf=useopen  " needed for pydoc
-
 endif
 
 


### PR DESCRIPTION
`plugin/jedi.vim` change `switchbuf` option. This effect to all users. It can keep changes until python filetype is loaded.
