### PR TITLE
fix python sys.path

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -174,14 +174,13 @@ import vim
 # update the system path, to include the jedi path
 import sys
 import os
-from os.path import dirname, abspath, join
-sys.path.insert(0, join(abspath(dirname(dirname(vim.eval('expand("<sfile>")')))+'/../plugin'), 'jedi'))
+sys.path.insert(0, os.path.join(vim.eval('expand("<sfile>:p:h:h")'), 'jedi'))
 
 # to display errors correctly
 import traceback
 
 # update the sys path to include the jedi_vim script
-sys.path.append(abspath(dirname(vim.eval('expand("<sfile>")'))+'/../plugin'))
+sys.path.append(os.path.join(vim.eval('expand("<sfile>:p:h:h")'), 'plugin'))
 import jedi_vim
 sys.path.pop()
 


### PR DESCRIPTION
This fixes following error:

```
Error detected while processing /home/hattya/.vim/bundle/jedi-vim/autoload/jedi.vim:
line  188:
Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "/home/hattya/.vim/bundle/jedi-vim/plugin/jedi_vim.py", line 11, in <module>
    import jedi
ImportError: No module named jedi
```

and also simplify path generation.
