### PR TITLE
fixed jedi#new_buffer() when g:jedi#use_tabs_not_buffers = 0

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -115,7 +115,7 @@ function! jedi#new_buffer(path)
         if !&hidden && &modified
             w
         endif
-        python vim.command('edit ' + vim.eval(jedi_vim.escape_file_path(vim.eval('a:path'))))
+        python vim.command('edit ' + jedi_vim.escape_file_path(vim.eval('a:path')))
     endif
 endfunction
 


### PR DESCRIPTION
This commit fixes the goto function when g:jedi#use_tabs_not_buffers = 0, by removing an extra vim.eval() call (and possibly other functions that use the jedi#new_buffer() function). Here is the error :

```
Error detected while processing function jedi#goto..jedi#new_buffer:
line    7:
E15: Invalid expression: /home/flupke/src/stupeflix/stupeflix/stupeflix/conf.py
E15: Invalid expression: /home/flupke/src/stupeflix/stupeflix/stupeflix/conf.py
Traceback (most recent call last):
  File "<string>", line 1, in <module>
vim.error: invalid expression
Error detected while processing function jedi#goto:
line    1:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/flupke/src/ext/jedi-vim/plugin/jedi_vim.py", line 139, in goto
    vim.current.window.cursor = d.line_nr, d.column
vim.error: cursor position outside buffer
```
