### PR TITLE
Squelch the +python warning during initialization

### DIFF
--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -6,7 +6,9 @@
 " lies in the python files around it.
 
 if !has('python')
-    echomsg "Error: Required vim compiled with +python"
+    if !exists("g:jedi#squelch_py_warning")
+        echomsg "Error: Required vim compiled with +python"
+    endif
     finish
 endif
 


### PR DESCRIPTION
If the user kicks off a version of vim with the jedi-vim plugin without
having Python support compiled in, it gives an error which halts vim
from starting up until it is dismissed. This commit adds a way to opt
out of that warning for people who use the same configuration and
plugins on different machines and different versions of vim.
