### PR TITLE
Fix #80 "Not an editor command: Python << PYTHONEOF"

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -159,6 +159,11 @@ function! jedi#configure_function_definition()
     autocmd CursorMovedI <buffer> call jedi#show_func_def()
 endfunction
 
+if has('python')
+    command! -nargs=1 Python python <args>
+else
+    command! -nargs=1 Python python3 <args>
+end
 
 Python << PYTHONEOF
 """ here we initialize the jedi stuff """

--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -51,11 +51,4 @@ if g:jedi#auto_initialization
     " order of invocation.
     autocmd FileType Python setlocal omnifunc=jedi#complete switchbuf=useopen  " needed for pydoc
 endif
-
-if has('python')
-    command! -nargs=1 Python python <args>
-else
-    command! -nargs=1 Python python3 <args>
-end
-
 " vim: set et ts=4:


### PR DESCRIPTION
Remove following piece of code from `plugin/jedi.vim` and add to `autoload/jedi.vim`

```
if has('python')
    command! -nargs=1 Python python <args>
else
    command! -nargs=1 Python python3 <args>
end
```
