### PR TITLE
Improved opening file in existing or new tab.

### DIFF
--- a/plugin/jedi_vim.py
+++ b/plugin/jedi_vim.py
@@ -304,8 +304,7 @@ def rename():
 def tabnew(path):
     "Open a file in a new tab or switch to an existing one"
     path = os.path.abspath(path)
-    has_gui = vim.eval('has("gui")') == '1'
-    if has_gui:
+    if vim.eval('has("gui")') == '1':
         vim.command('tab drop %s' % path)
         return
 


### PR DESCRIPTION
The `tabnew` command always opens a new tab, it is easier to let vim check if the file is open and reuse the tab or open a new tab by using the `tab drop <path>` command.

Maybe this could be applied to opening files in buffers also, using the `drop <path>` instead of the `edit` command. I think this could avoid some autocommands to be called unnecessarily.

Reference:
http://vim.wikia.com/wiki/Edit_a_file_or_jump_to_it_if_already_open

Possibly related issues:
https://github.com/davidhalter/jedi-vim/issues/65
https://github.com/davidhalter/jedi-vim/issues/87
