### PR TITLE
Silence dot completion mappings

### DIFF
--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -41,13 +41,13 @@ end
 if g:jedi#popup_on_dot
     if stridx(&completeopt, 'longest') > -1
         if g:jedi#popup_select_first
-            inoremap <buffer> . .<C-R>=jedi#do_popup_on_dot() ? "\<lt>C-X>\<lt>C-O>\<lt>C-N>" : ""<CR>
+            inoremap <silent> <buffer> . .<C-R>=jedi#do_popup_on_dot() ? "\<lt>C-X>\<lt>C-O>\<lt>C-N>" : ""<CR>
         else
-            inoremap <buffer> . .<C-R>=jedi#do_popup_on_dot() ? "\<lt>C-X>\<lt>C-O>" : ""<CR>
+            inoremap <silent> <buffer> . .<C-R>=jedi#do_popup_on_dot() ? "\<lt>C-X>\<lt>C-O>" : ""<CR>
         end
 
     else
-        inoremap <buffer> . .<C-R>=jedi#do_popup_on_dot() ? "\<lt>C-X>\<lt>C-O>\<lt>C-P>" : ""<CR>
+        inoremap <silent> <buffer> . .<C-R>=jedi#do_popup_on_dot() ? "\<lt>C-X>\<lt>C-O>\<lt>C-P>" : ""<CR>
     end
 end
 


### PR DESCRIPTION
First pull request ever, I hope I'm not doing anything wrong.

I find the long line that pops up in the command-line whenever I press
`.` a bit distracting, and it would potentially overwrite other useful
information displayed in there. This change silences the dot completion
commands.

On the other hand, it might be useful to have visual feedback that
something happens while one waits for a large module to be parsed.

So basically, this is just a cosmetic change and I completely understand
if you don't want to merge it.
