### PR TITLE
Fix new tabs overriding default syntax rules

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -97,8 +97,12 @@ function! jedi#new_buffer(path)
         Python vim.command('edit ' + jedi_vim.escape_file_path(vim.eval('a:path')))
     endif
     " sometimes syntax is being disabled and the filetype not set.
-    syntax on
-    set filetype=python
+    if !exists("g:syntax_on")
+      syntax enable
+    endif
+    if &filetype != 'python'
+      set filetype=python
+    endif
 endfunction
 
 function! jedi#add_goto_window()


### PR DESCRIPTION
Fixes #103, #87, and #65

Calling `syntax on` will override existing syntax rules with default
ones. This ends up adding a bunch of syntax rules that users have
disabled.

See `:help syntax` for this snippet:

```
The ":syntax enable" command will keep your current color settings. This
allows using ":highlight" commands to set your preferred colors before or
after using this command.  If you want Vim to overrule your settings with
the defaults, use: `:syntax on`
```

Calling `:syntax enable` doesn't appear to work either. It does the same thing
as `:syntax on`. So the solution implemented here is to conditionally set the
filetype and syntax rules when they aren't already set.
