### PR TITLE
Pyedit command to open module files with jedi completion for module names

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -104,7 +104,7 @@ endfunction
 function! jedi#add_goto_window()
     set lazyredraw
     cclose
-    execute 'belowright copen 3'
+    execute 'belowright copen '.g:jedi#quickfix_window_height
     set nolazyredraw
     if g:jedi#use_tabs_not_buffers == 1
         map <buffer> <CR> :call jedi#goto_window_on_enter()<CR>

--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -35,7 +35,8 @@ let s:settings = {
     \ 'show_function_definition': 1,
     \ 'function_definition_escape': "'≡'",
     \ 'auto_close_doc': 1,
-    \ 'popup_select_first': 1
+    \ 'popup_select_first': 1,
+    \ 'quickfix_window_height': 10
 \ }
 
 for [key, val] in items(s:settings)


### PR DESCRIPTION
:Pyedit [++opt] [+cmd] module

```
module is a python module, there is a completion for them as well.
[opt] and [cmd] are like for the :edit command.
```

Secondly add a g:jedi#quickfix_window_height option, since 3 (the current option) seems arbitrary and does not reflect the vim default (which is 10, ":help :copen")
