### PR TITLE
Remove highlights from a syntax file

### DIFF
--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -14,8 +14,8 @@ if g:jedi#show_function_definition == 1 && has('conceal')
   hi def link jediIgnore Ignore
   hi def link jediFatSymbol Ignore
   hi def link jediSpace Normal
-  hi jediFat term=bold,underline cterm=bold,underline gui=bold,underline ctermbg=0 guibg=#555555
-  hi jediFunction term=NONE cterm=NONE ctermfg=6 guifg=Black gui=NONE ctermbg=0 guibg=Grey
+  hi def link jediFat Pmenu
+  hi def link jediFunction Pmenu
 
   " override defaults (add jediFunction to contains)
   syn match pythonComment "#.*$" contains=pythonTodo,@Spell,jediFunction


### PR DESCRIPTION
the commands:
    hi jediFunction ...
    hi jediFat ...
    should not be used in a syntax file.  They belongs to a colorscheme
    script.  When they are present they reset colors set by
    a colorscheme script after openning a new python file when
    after/syntax/python.vim is executed (and a colorscheme script is
    not).  The default values should be set by 'hi def link' command.
    I set the default to
    hi def link jediFat Pmenu
    hi def link jediFunction Pmenu
    since Pmenu is used in a similar situation.
