### PR TITLE
Modify IndexError to LookupError in tabnew

### DIFF
--- a/plugin/jedi_vim.py
+++ b/plugin/jedi_vim.py
@@ -324,7 +324,7 @@ def tabnew(path):
             buf_nr = int(buf_nr) - 1
             try:
                 buf_path = vim.buffers[buf_nr].name
-            except IndexError:
+            except LookupError:
                 # Just do good old asking for forgiveness.
                 # don't know why this happens :-)
                 pass


### PR DESCRIPTION
With python 3.3.2 and vim 7.3.1214, a bad access to vim.buffers throw an "KeyError" and not a "IndexError".
