### PR TITLE
after/ftplugin/python/jedi.vim takes care of setting the omnifunc, it's not needed in ftplugin/python/jedi.vim anymore.

### DIFF
--- a/after/ftplugin/python/jedi.vim
+++ b/after/ftplugin/python/jedi.vim
@@ -1,3 +1,16 @@
-" We need our own omnifunc, so this overrides the omnifunc set by
-" $VIMRUNTIME/ftplugin/python.vim.
-setlocal omnifunc=jedi#completions
+if g:jedi#auto_initialization
+    if g:jedi#completions_enabled
+        " We need our own omnifunc, so this overrides the omnifunc set by
+        " $VIMRUNTIME/ftplugin/python.vim.
+        setlocal omnifunc=jedi#completions
+
+        " map ctrl+space for autocompletion
+        if g:jedi#completions_command == "<C-Space>"
+            " in terminals, <C-Space> sometimes equals <Nul>
+            inoremap <expr> <Nul> jedi#complete_string(0)
+        endif
+        if g:jedi#completions_command != ""
+            execute "inoremap <expr> <buffer> ".g:jedi#completions_command." jedi#complete_string(0)"
+        endif
+    endif
+endif

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -6,17 +6,6 @@ endif
 " ------------------------------------------------------------------------
 
 if g:jedi#auto_initialization
-    if g:jedi#completions_enabled
-        " map ctrl+space for autocompletion
-        if g:jedi#completions_command == "<C-Space>"
-            " in terminals, <C-Space> sometimes equals <Nul>
-            inoremap <expr> <Nul> jedi#complete_string(0)
-        endif
-        if g:jedi#completions_command != ""
-            execute "inoremap <expr> <buffer> ".g:jedi#completions_command." jedi#complete_string(0)"
-        endif
-    endif
-
     " goto / get_definition / usages
     if g:jedi#goto_assignments_command != ''
         execute "noremap <buffer>".g:jedi#goto_assignments_command." :call jedi#goto_assignments()<CR>"


### PR DESCRIPTION
This avoids calling setlocal twice.

Regards,
Yann
