### PR TITLE
fix #223: xnoremap/nnoremap instead of noremap

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -197,7 +197,6 @@ endfunction
 " ------------------------------------------------------------------------
 " deprecations
 " ------------------------------------------------------------------------
-
 let s:deprecations = {
     \ 'get_definition_command':     'goto_definitions_command',
     \ 'goto_command':               'goto_assignments_command',
@@ -207,18 +206,9 @@ let s:deprecations = {
     \ 'show_function_definition':   'show_call_signatures',
 \ }
 
-for [key, val] in items(s:deprecations)
-    if exists('g:jedi#'.key)
-        echom "'g:jedi#".key."' is deprecated. Please use 'g:jedi#".val."' instead. Sorry for the inconvenience."
-        exe 'let g:jedi#'.val.' = g:jedi#'.key
-    end
-endfor
-
-
 " ------------------------------------------------------------------------
 " defaults for jedi-vim
 " ------------------------------------------------------------------------
-
 let s:settings = {
     \ 'use_tabs_not_buffers': 1,
     \ 'use_splits_not_buffers': 1,
@@ -240,12 +230,21 @@ let s:settings = {
     \ 'completions_enabled': 1
 \ }
 
-for [key, val] in items(s:settings)
-    if !exists('g:jedi#'.key)
-        exe 'let g:jedi#'.key.' = '.val
-    endif
-endfor
+function! s:init()
+  for [key, val] in items(s:deprecations)
+      if exists('g:jedi#'.key)
+          echom "'g:jedi#".key."' is deprecated. Please use 'g:jedi#".val."' instead. Sorry for the inconvenience."
+          exe 'let g:jedi#'.val.' = g:jedi#'.key
+      end
+  endfor
+  for [key, val] in items(s:settings)
+      if !exists('g:jedi#'.key)
+          exe 'let g:jedi#'.key.' = '.val
+      endif
+  endfor
+endfunction
 
+call s:init()
 
 " ------------------------------------------------------------------------
 " Python initialization

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -5,41 +5,53 @@ endif
 " Initialization of jedi-vim
 " ------------------------------------------------------------------------
 
-if g:jedi#auto_initialization
-    " goto / get_definition / usages
-    if g:jedi#goto_assignments_command != ''
-        execute "noremap <buffer>".g:jedi#goto_assignments_command." :call jedi#goto_assignments()<CR>"
-    endif
-    if g:jedi#goto_definitions_command != ''
-        execute "noremap <buffer>".g:jedi#goto_definitions_command." :call jedi#goto_definitions()<CR>"
-    endif
-    if g:jedi#usages_command != ''
-        execute "noremap <buffer>".g:jedi#usages_command." :call jedi#usages()<CR>"
-    endif
-    " rename
-    if g:jedi#rename_command != ''
-        execute "noremap <buffer>".g:jedi#rename_command." :call jedi#rename()<CR>"
-    endif
-    " documentation/pydoc
-    if g:jedi#documentation_command != ''
-        execute "nnoremap <silent> <buffer>".g:jedi#documentation_command." :call jedi#show_documentation()<CR>"
-    endif
+function! s:init()
+  if g:jedi#auto_initialization
+      " goto / get_definition / usages
+      if g:jedi#goto_assignments_command != ''
+          for k in ['n', 'x']
+              execute k."noremap <buffer> ".g:jedi#goto_assignments_command." :call jedi#goto_assignments()<CR>"
+          endfor
+      endif
+      if g:jedi#goto_definitions_command != ''
+          for k in ['n', 'x']
+              execute k."noremap <buffer> ".g:jedi#goto_definitions_command." :call jedi#goto_definitions()<CR>"
+          endfor
+      endif
+      if g:jedi#usages_command != ''
+          for k in ['n', 'x']
+              execute k."noremap <buffer> ".g:jedi#usages_command." :call jedi#usages()<CR>"
+          endfor
+      endif
+      " rename
+      if g:jedi#rename_command != ''
+          for k in ['n', 'x']
+              execute k."noremap <buffer> ".g:jedi#rename_command." :call jedi#rename()<CR>"
+          endfor
+      endif
+      " documentation/pydoc
+      if g:jedi#documentation_command != ''
+          execute "nnoremap <silent> <buffer>".g:jedi#documentation_command." :call jedi#show_documentation()<CR>"
+      endif
 
-    if g:jedi#show_call_signatures == 1 && has('conceal')
-        call jedi#configure_call_signatures()
-    endif
+      if g:jedi#show_call_signatures == 1 && has('conceal')
+          call jedi#configure_call_signatures()
+      endif
 
-    inoremap <silent> <buffer> . .<C-R>=jedi#complete_string(1)<CR>
+      inoremap <silent> <buffer> . .<C-R>=jedi#complete_string(1)<CR>
 
-    if g:jedi#auto_close_doc
-        " close preview if its still open after insert
-        autocmd InsertLeave <buffer> if pumvisible() == 0|pclose|endif
-    end
-end
+      if g:jedi#auto_close_doc
+          " close preview if its still open after insert
+          autocmd InsertLeave <buffer> if pumvisible() == 0|pclose|endif
+      end
+  end
 
-if g:jedi#auto_vim_configuration
-    setlocal completeopt=menuone,longest,preview
-    if len(mapcheck('<C-c>', 'i')) == 0
-        inoremap <C-c> <ESC>
-    end
-end
+  if g:jedi#auto_vim_configuration
+      setlocal completeopt=menuone,longest,preview
+      if len(mapcheck('<C-c>', 'i')) == 0
+          inoremap <C-c> <ESC>
+      end
+  end
+endfunction
+
+call s:init()


### PR DESCRIPTION
- mapping operator-pending-mode and selection-mode has undesirable side-effects, and isn't actually used by jedi-vim, so map only to normal-mode and visual-mode.
- also, wrap 'for' loops in s:init() functions to avoid polluting the global namespace ('for key in keys' assigns g:key).
