### PR TITLE
add expand to make paths which contains spaces work correctly

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -11,13 +11,13 @@ import os
 
 # vim.command('echom expand("<sfile>:p:h:h")') # broken, <sfile> inside function
 # sys.path.insert(0, os.path.join(vim.eval('expand("<sfile>:p:h:h")'), 'jedi'))
-sys.path.insert(0, os.path.join(vim.eval('s:script_path'), 'jedi'))
+sys.path.insert(0, os.path.join(vim.eval('expand(s:script_path)'), 'jedi'))
 
 # to display errors correctly
 import traceback
 
 # update the sys path to include the jedi_vim script
-sys.path.insert(0, vim.eval('s:script_path'))
+sys.path.insert(0, vim.eval('expand(s:script_path)'))
 try:
     import jedi_vim
 except ImportError:


### PR DESCRIPTION
Adding `expand()` to fix issue: https://github.com/davidhalter/jedi-vim/issues/239
