### PR TITLE
improve show_call_signatures performance

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -20,7 +20,7 @@ Jean-Louis Fuchs (@ganwell) <ganwell@fangorn.ch>
 Mathieu Comandon (@strycore) <strider@strycore.com>
 Nick Hurley (@todesschaf) <hurley@todesschaf.org>
 gpoulin (@gpoulin)
-Akinori Hattori (@hattya)
+Akinori Hattori (@hattya) <hattya@gmail.com>
 Luper Rouch (@flupke)
 Matthew Moses (@mlmoses) <moses.matthewl@gmail.com>
 Tyler Wymer (@twymer)

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -154,6 +154,7 @@ endfunction
 
 function! jedi#configure_call_signatures()
     autocmd InsertLeave <buffer> Python jedi_vim.clear_call_signatures()
+    autocmd InsertLeave <buffer> Python jedi_vim.invalidate_signatures_cache()
     autocmd CursorMovedI <buffer> Python jedi_vim.show_call_signatures()
 endfunction
 


### PR DESCRIPTION
The current implementation of `show_call_signatures` is:

1. fire `CursorMovedI`
2. parse the current buffer
3. show call signatures

These steps are processed on every cursor move.

This tries to reduce parsing the current buffer as much as possible.
I hope this fixes #217.