### PR TITLE
Documentation about the need for `+conceal`

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -43,6 +43,7 @@ Doan Thanh Nam (@tndoan)
 Markus Koller (@toupeira)
 Justin Cheevers @justincheevers
 Talha Ahmed (@talha81) <talha.ahmed@gmail.com>
+Matthew Tylee Atkinson (@matatk)
 
 
 @something are github user names.

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Documentation
 =============
 
 Documentation is available in your vim: ``:help jedi-vim``. You can also look
-it up `on github <http://github.com/davidhalter/jedi-vim>`_.
+it up `on github <http://github.com/davidhalter/jedi-vim/blob/master/doc/jedi-vim.txt>`_.
 
 You can read the Jedi library documentation `here <http://jedi.jedidjah.ch>`_.
 
@@ -92,9 +92,12 @@ Note that the `python-mode <https://github.com/klen/python-mode>`_ VIM plugin se
 to conflict with jedi-vim, therefore you should disable it before enabling
 jedi-vim.
 
-To enjoy the full features of Jedi-Vim, you should have VIM >= 7.3. For older 
-version of VIM, the parameter recommendation list maybe not appeared when you type
-open bracket after the function name.
+To enjoy the full features of jedi-vim, you should have VIM >= 7.3, compiled with
+``+conceal`` (which is not the case on some platforms, including OS X). If your VIM
+does not meet these requirements, the parameter recommendation list may not appear
+when you type an open bracket after a function name. Please read
+`the documentation <http://github.com/davidhalter/jedi-vim/blob/master/doc/jedi-vim.txt>`_
+for details.
 
 
 Settings

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -1,4 +1,4 @@
-*jedi-vim.txt* - For Vim version 7.3 - Last change: 2013/3/1
+*jedi-vim.txt* - For Vim version 7.3 - Last change: 2014/07/29
        __   _______  _______   __       ____    ____  __  .___  ___.~
       |  | |   ____||       \ |  |      \   \  /   / |  | |   \/   |~
       |  | |  |__   |  .--.  ||  |  _____\   \/   /  |  | |  \  /  |~
@@ -82,9 +82,22 @@ using pip: >
 However, you can also install it as a git submodule if you don't want to use
 jedi for anything but this plugin. How to do this is detailed below.
 
-It is the best if you have VIM >= 7.3. For the older version, you probably 
-cannot see the parameter recommendation list of function after typing open 
-bracket.
+It is best if you have VIM >= 7.3, compiled with the `+conceal` option. With
+older versions, you will probably not see the parameter recommendation list
+for functions after typing the open bracket. Some platforms (including OS X
+releases) do not ship a VIM with `+conceal`. You can check if your VIM has the
+feature with >
+
+    :ver
+
+and look for "`+conceal`" (as opposed to "`-conceal`") or >
+
+    :echo has('conceal')
+
+which will report 0 (not included) or 1 (included). If your VIM lacks this
+feature and you would like function parameter completion, you will need to
+build your own VIM, or use a package for your operating system that has this
+feature (such as MacVim on OS X, which also contains a console binary).
 
 ------------------------------------------------------------------------------
 2.1. Installing manually		*jedi-vim-installation-manually*


### PR DESCRIPTION
This is in relation to the documentation concerning `+conceal`, as discussed in #97.  I have added a small note to the README as well as full details to the main documentation...
- Make README link to the text file point to the file (not the repo)
- Replace the one 'Jedi-Vim' with 'jedi-vim' in README
- Minor grammar tweak to VIM >= 7.3 requirement in the docs
- Explain the need for `+conceal` in the docs
- Update last-changed date on first line of the docs
- Hint at the need for `+conceal` in the README
