### PR TITLE
Use newer Vundle syntax

### DIFF
--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -125,11 +125,11 @@ Pathogen simplifies installation considerably.
    will automatically get the jedi library with the jedi-vim plugin. Add the
    following to the Bundles section in your .vimrc file: >
 
-    Bundle 'git://github.com/davidhalter/jedi-vim'
+    Plugin 'davidhalter/jedi-vim'
 
 2. Issue the following command in Vim: >
 
-    :BundleInstall
+    :PluginInstall
 
 Help tags are generated automatically, so you should be good to go.
 


### PR DESCRIPTION
Vundle has deprecated the `Bundle` syntax, replacing it with `Plugin`.

I've also added the abbreviated GitHub syntax (simply `username/repo`,
no need to pass the full git URL).
