### PR TITLE
Escape quotes in command line call signatures

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -331,7 +331,7 @@ def cmdline_call_signatures(signatures):
         params = ['(' + ', '.join(p) + ')' for p in params]
     else:
         params = get_params(signatures[0])
-    text = ', '.join(params)
+    text = ', '.join(params).replace('"', '\\"')
 
     # Allow 12 characters for ruler/showcmd - setting noruler/noshowcmd
     # here causes incorrect undo history


### PR DESCRIPTION
Fixes https://github.com/davidhalter/jedi-vim/issues/341
