### PR TITLE
Don't clear command line call signatures in completions()

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -104,6 +104,8 @@ def get_script(source=None, column=None):
 @catch_and_print_exceptions
 def completions():
     row, column = vim.current.window.cursor
+    # Clear call signatures in the buffer so they aren't seen by the completer.
+    # Call signatures in the command line can stay.
     if vim_eval("g:jedi#show_call_signatures") == '1':
         clear_call_signatures()
     if vim.eval('a:findstart') == '1':

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -104,7 +104,8 @@ def get_script(source=None, column=None):
 @catch_and_print_exceptions
 def completions():
     row, column = vim.current.window.cursor
-    clear_call_signatures()
+    if vim_eval("g:jedi#show_call_signatures") == '1':
+        clear_call_signatures()
     if vim.eval('a:findstart') == '1':
         count = 0
         for char in reversed(vim.current.line[:column]):


### PR DESCRIPTION
NeoComplete calls Jedi's `completefunc` frequently which clears Jedi's call signatures. This commit prevents command line call signatures from being cleared but doesn't affect the regular call signatures because they can errantly change the results of Jedi's completion function if not cleared.