### PR TITLE
Remove duplicate signatures when show_call_signatures called

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -265,6 +265,7 @@ def show_call_signatures(signatures=()):
 
     if not signatures:
         return
+    signatures = list(set(signatures))
 
     if vim_eval("g:jedi#show_call_signatures") == '2':
         return cmdline_call_signatures(signatures)


### PR DESCRIPTION
Jedi-vim showed duplicated signatures like below when show_call_signatures  is enable.
So I solve this probelm by remove duplicate signatures.

![screenshot_from_2015-01-10 20 07 12](https://cloud.githubusercontent.com/assets/5734732/5691330/6e7e0fbc-9904-11e4-8867-a7b8d4887fd2.png)

For reprodue:

``` python
improt numpy as np
np.abs() #cursor is in  parenthes
```
