### PR TITLE
Escape newlines in call signatures with show_call_signatures=2

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -334,7 +334,7 @@ def cmdline_call_signatures(signatures):
         params = ['(' + ', '.join(p) + ')' for p in params]
     else:
         params = get_params(signatures[0])
-    text = ', '.join(params).replace('"', '\\"')
+    text = ', '.join(params).replace('"', '\\"').replace(r'\n', r'\\n')
 
     # Allow 12 characters for ruler/showcmd - setting noruler/noshowcmd
     # here causes incorrect undo history


### PR DESCRIPTION
Currently the command line call signature treats '\n' in a string as a literal newline (e.g. in the call signature for `print()`) and this just escapes the newline so it is printed as literal '\n'.