### PR TITLE
Add 'winwidth' split option

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,6 +44,7 @@ Markus Koller (@toupeira)
 Justin Cheevers @justincheevers
 Talha Ahmed (@talha81) <talha.ahmed@gmail.com>
 Matthew Tylee Atkinson (@matatk)
+Pedro Ferrari (@petobens)
 
 
 @something are github user names.

--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ If you are a person who likes to use VIM-splits, you might want to put this in y
 
     let g:jedi#use_splits_not_buffers = "left"
 
-This options could be "left", "right", "top" or "bottom". It will decide the direction where the split open.
+This options could be "left", "right", "top", "bottom" or "winwidth". It will decide the direction where the split open.
 
 Jedi automatically starts the completion, if you type a dot, e.g. ``str.``, if
 you don't want this:
@@ -193,7 +193,7 @@ This depends on the ``completeopt`` option. Jedi initializes it in its
 I want <Tab> to do autocompletion
 ---------------------------------
 
-Don't even think about changing the Jedi command to ``<Tab>``, 
+Don't even think about changing the Jedi command to ``<Tab>``,
 use `supertab <https://github.com/ervandew/supertab>`_!
 
 

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -432,6 +432,11 @@ direction which you want to open a split with.
 Options: top, left, right, bottom or winwidth
 Default: "" (not enabled by default)
 
+Note: with the 'winwidth' option the window is split vertically or horizontally
+depending on the width of the window relative to 'textwidth'. This essentially
+means that if the window is big enough it will be split vertically but if it is
+small a horizontal split happens.
+
 ------------------------------------------------------------------------------
 6.11. `g:jedi#force_py_version`                *g:jedi#force_py_version*
 

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -429,7 +429,7 @@ Default: 1
 If you want to open new split for "go to", you could set this option to the
 direction which you want to open a split with.
 
-Options: top, left, right or bottom
+Options: top, left, right, bottom or winwidth
 Default: "" (not enabled by default)
 
 ------------------------------------------------------------------------------

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -469,8 +469,12 @@ def new_buffer(path, options=''):
             'top': 'topleft split',
             'left': 'topleft vsplit',
             'right': 'botright vsplit',
-            'bottom': 'botright split'
+            'bottom': 'botright split',
+            'winwidth': 'vs'
         }
+        if user_split_option == 'winwidth' and vim.current.window.width <= 2 * int(vim_eval("&tw ? &tw : 80")):
+            for key, value in split_options.items():
+                split_options['winwidth'] = 'sp'
         if user_split_option not in split_options:
             print('g:jedi#use_splits_not_buffers value is not correct, valid options are: %s' % ','.join(split_options.keys()))
         else:

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -472,9 +472,8 @@ def new_buffer(path, options=''):
             'bottom': 'botright split',
             'winwidth': 'vs'
         }
-        if user_split_option == 'winwidth' and vim.current.window.width <= 2 * int(vim_eval("&tw ? &tw : 80")):
-            for key, value in split_options.items():
-                split_options['winwidth'] = 'sp'
+        if user_split_option == 'winwidth' and vim.current.window.width <= 2 * int(vim_eval("&textwidth ? &textwidth : 80")):
+            split_options['winwidth'] = 'sp'
         if user_split_option not in split_options:
             print('g:jedi#use_splits_not_buffers value is not correct, valid options are: %s' % ','.join(split_options.keys()))
         else:


### PR DESCRIPTION
This allows to open a new split for "go to" in a vertical or horizontal split depending on the current window width. 