### PR TITLE
Do not overwrite/re-define pythonString syntax regions

### DIFF
--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -9,7 +9,9 @@ if g:jedi#show_call_signatures > 0 && has('conceal')
     syn match jediFatSymbol "*" contained conceal
     syn match jediFat "\*[^*]\+\*" contained contains=jediFatSymbol
     syn match jediSpace "\v[ ]+( )@=" contained
-    exe 'syn match jediFunction "'.s:l1.'" keepend extend contains=jediIgnore,jediFat,jediSpace'
+    exe 'syn match jediFunction "'.s:l1.'" keepend extend '
+                \ .' contains=jediIgnore,jediFat,jediSpace'
+                \ .' containedin=pythonComment,pythonString,pythonRawString'
     unlet! s:e s:l1 s:l2
  
     hi def link jediIgnore Ignore
@@ -23,19 +25,4 @@ if g:jedi#show_call_signatures > 0 && has('conceal')
         hi jediFunction term=NONE cterm=NONE ctermfg=6 guifg=Black gui=NONE ctermbg=0 guibg=Grey
         hi jediFat term=bold,underline cterm=bold,underline gui=bold,underline ctermbg=0 guibg=#555555
     end
- 
-    " override defaults (add jediFunction to contains)
-    syn match pythonComment "#.*$" contains=pythonTodo,@Spell,jediFunction
-    syn region pythonString
-        \ start=+[uU]\=\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
-        \ contains=pythonEscape,@Spell,jediFunction
-    syn region pythonString
-        \ start=+[uU]\=\z('''\|"""\)+ end="\z1" keepend
-        \ contains=pythonEscape,pythonSpaceError,pythonDoctest,@Spell,jediFunction
-    syn region pythonRawString
-        \ start=+[uU]\=[rR]\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
-        \ contains=@Spell,jediFunction
-    syn region pythonRawString
-        \ start=+[uU]\=[rR]\z('''\|"""\)+ end="\z1" keepend
-        \ contains=pythonSpaceError,pythonDoctest,@Spell,jediFunction
 endif


### PR DESCRIPTION
Use `containedin` instead with `jediFunction`.

This adopts any changes to the syntax definitions, instead of overwriting them.

I am not really sure how to test if it doesn't break anything.

Followup to #366, this time against master - the dev branch appears to be outdated..