### PR TITLE
Set 'hide documentation' to jedi#documentation_command

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -45,6 +45,7 @@ Justin Cheevers @justincheevers
 Talha Ahmed (@talha81) <talha.ahmed@gmail.com>
 Matthew Tylee Atkinson (@matatk)
 Pedro Ferrari (@petobens)
+Dave Honneffer (@pearofducks)
 
 
 @something are github user names.

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -80,7 +80,7 @@ function! jedi#show_documentation()
 
     " quit comands
     nnoremap <buffer> q ZQ
-    nnoremap <buffer> K ZQ
+    execute "nnoremap <buffer> ".g:jedi#documentation_command." ZQ"
 
     " highlight python code within rst
     unlet! b:current_syntax


### PR DESCRIPTION
With default binding ("K") - `jedi#show_documentation()` behaves like a toggle. This behavior isn't replicated with a custom binding. This PR fixes that.