### PR TITLE
add_goto_window: pass len of list and use min()

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -96,10 +96,11 @@ endfunction
 " helper functions
 " ------------------------------------------------------------------------
 
-function! jedi#add_goto_window()
+function! jedi#add_goto_window(len)
     set lazyredraw
     cclose
-    execute 'belowright copen '.g:jedi#quickfix_window_height
+    let height = min([a:len, g:jedi#quickfix_window_height])
+    execute 'belowright copen '.height
     set nolazyredraw
     if g:jedi#use_tabs_not_buffers == 1
         noremap <buffer> <CR> :call jedi#goto_window_on_enter()<CR>

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -236,7 +236,7 @@ def goto(is_definition=False, is_related_name=False, no_output=False):
                                     lnum=d.line, col=d.column + 1,
                                     text=PythonToVimStr(d.description)))
             vim_eval('setqflist(%s)' % repr(lst))
-            vim_eval('jedi#add_goto_window()')
+            vim_eval('jedi#add_goto_window(' + str(len(lst)) + ')')
     return definitions
 
 


### PR DESCRIPTION
With less than `g:jedi#quickfix_window_height` entries in quickfix list,
this now only makes the window that large, effectively saving screen
space.

Maybe a new setting should be used for this instead, in case not having the same height always for the quickfix window might be an issue for someone?!