### PR TITLE
"auto" for force_py_version; optimize for Neovim; refactor init

### DIFF
--- a/after/ftplugin/python/jedi.vim
+++ b/after/ftplugin/python/jedi.vim
@@ -1,3 +1,7 @@
+if !jedi#init_python()
+    finish
+endif
+
 if g:jedi#auto_initialization
     if g:jedi#completions_enabled
         " We need our own omnifunc, so this overrides the omnifunc set by

--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -1,6 +1,10 @@
+if !jedi#init_python()
+    finish
+endif
+
 if g:jedi#show_call_signatures > 0 && has('conceal')
     " +conceal is the default for vim >= 7.3
- 
+
     let s:e = g:jedi#call_signature_escape
     let s:full = s:e.'jedi=.\{-}'.s:e.'.\{-}'.s:e.'jedi'.s:e
     let s:ignore = s:e.'jedi.\{-}'.s:e
@@ -13,11 +17,11 @@ if g:jedi#show_call_signatures > 0 && has('conceal')
                 \ .' contains=jediIgnore,jediFat,jediSpace'
                 \ .' containedin=pythonComment,pythonString,pythonRawString'
     unlet! s:e s:full s:ignore
- 
+
     hi def link jediIgnore Ignore
     hi def link jediFatSymbol Ignore
     hi def link jediSpace Normal
- 
+
     if exists('g:colors_name')
         hi def link jediFunction CursorLine
         hi def link jediFat TabLine

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -4,43 +4,43 @@ scriptencoding utf-8
 " functions that call python code
 " ------------------------------------------------------------------------
 function! jedi#goto_assignments()
-    Python jedi_vim.goto()
+    PythonJedi jedi_vim.goto()
 endfunction
 
 function! jedi#goto_definitions()
-    Python jedi_vim.goto(is_definition=True)
+    PythonJedi jedi_vim.goto(is_definition=True)
 endfunction
 
 function! jedi#usages()
-    Python jedi_vim.goto(is_related_name=True)
+    PythonJedi jedi_vim.goto(is_related_name=True)
 endfunction
 
 function! jedi#rename(...)
-    Python jedi_vim.rename()
+    PythonJedi jedi_vim.rename()
 endfunction
 
 function! jedi#completions(findstart, base)
-    Python jedi_vim.completions()
+    PythonJedi jedi_vim.completions()
 endfunction
 
 function! jedi#enable_speed_debugging()
-    Python jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout, speed=True, warnings=False, notices=False)
+    PythonJedi jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout, speed=True, warnings=False, notices=False)
 endfunction
 
 function! jedi#enable_debugging()
-    Python jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout)
+    PythonJedi jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout)
 endfunction
 
 function! jedi#disable_debugging()
-    Python jedi_vim.jedi.set_debug_function(None)
+    PythonJedi jedi_vim.jedi.set_debug_function(None)
 endfunction
 
 function! jedi#py_import(args)
-    Python jedi_vim.py_import()
+    PythonJedi jedi_vim.py_import()
 endfun
 
 function! jedi#py_import_completions(argl, cmdl, pos)
-    Python jedi_vim.py_import_completions()
+    PythonJedi jedi_vim.py_import_completions()
 endfun
 
 
@@ -48,7 +48,7 @@ endfun
 " show_documentation
 " ------------------------------------------------------------------------
 function! jedi#show_documentation()
-    Python if jedi_vim.show_documentation() is None: vim.command('return')
+    PythonJedi if jedi_vim.show_documentation() is None: vim.command('return')
 
     let bn = bufnr("__doc__")
     if bn > 0
@@ -116,7 +116,7 @@ function! jedi#goto_window_on_enter()
     if l:data.bufnr
         " close goto_window buffer
         normal ZQ
-        Python jedi_vim.new_buffer(vim.eval('bufname(l:data.bufnr)'))
+        PythonJedi jedi_vim.new_buffer(vim.eval('bufname(l:data.bufnr)'))
         call cursor(l:data.lnum, l:data.col)
     else
         echohl WarningMsg | echo "Builtin module cannot be opened." | echohl None
@@ -160,8 +160,8 @@ function! jedi#configure_call_signatures()
         endif
         autocmd InsertEnter <buffer> let g:jedi#first_col = s:save_first_col()
     endif
-    autocmd InsertLeave <buffer> Python jedi_vim.clear_call_signatures()
-    autocmd CursorMovedI <buffer> Python jedi_vim.show_call_signatures()
+    autocmd InsertLeave <buffer> PythonJedi jedi_vim.clear_call_signatures()
+    autocmd CursorMovedI <buffer> PythonJedi jedi_vim.show_call_signatures()
 endfunction
 
 " Determine where the current window is on the screen for displaying call
@@ -258,10 +258,10 @@ function! jedi#force_py_version(py_version)
     let g:jedi#force_py_version = a:py_version
     try
         if g:jedi#force_py_version == 2
-            command! -nargs=1 Python python <args>
+            command! -nargs=1 PythonJedi python <args>
             execute 'pyfile '.s:script_path.'/initialize.py'
         elseif g:jedi#force_py_version == 3
-            command! -nargs=1 Python python3 <args>
+            command! -nargs=1 PythonJedi python3 <args>
             execute 'py3file '.s:script_path.'/initialize.py'
         endif
     catch
@@ -371,10 +371,10 @@ else
     if g:jedi#force_py_version == 'auto'
         " If it's still "auto", it wasn't handled above.
         if has('python')
-            command! -nargs=1 Python python <args>
+            command! -nargs=1 PythonJedi python <args>
             execute 'pyfile '.s:script_path.'/initialize.py'
         elseif has('python3')
-            command! -nargs=1 Python python3 <args>
+            command! -nargs=1 PythonJedi python3 <args>
             execute 'py3file '.s:script_path.'/initialize.py'
         else
             if !exists("g:jedi#squelch_py_warning")
@@ -385,7 +385,7 @@ else
 endif
 
 
-"Python jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout, speed=True, warnings=False, notices=False)
-"Python jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout)
+"PythonJedi jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout, speed=True, warnings=False, notices=False)
+"PythonJedi jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout)
 
 " vim: set et ts=4:

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -352,7 +352,9 @@ function! jedi#get_force_py_version()
     return g:jedi#force_py_version
 endfunction
 
-if has('python') && has('python3')
+" NOTE: nvim usually has both python providers. Skipping the `has` check
+" avoids starting both of them.
+if has('nvim') || (has('python') && has('python3'))
     " Use default python with Jedi.
     call jedi#force_py_version(jedi#get_force_py_version())
 elseif has('python')

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -106,7 +106,7 @@ function! jedi#init_python()
         catch
             if !exists("g:jedi#squelch_py_warning")
                 echohl WarningMsg
-                echom "Error: jedi-vim failed to initialize Python: ".v:exception
+                echom "Error: jedi-vim failed to initialize Python: ".v:exception." (in ".v:throwpoint.")"
                 echohl None
             endif
             let s:_init_python = 0

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -337,38 +337,38 @@ call s:init()
 
 let s:script_path = fnameescape(expand('<sfile>:p:h:h'))
 
-" Get g:jedi#force_py_version, handling "auto" on first call.
-function! jedi#get_force_py_version()
-    if g:jedi#force_py_version == 'auto'
-        let s:def_py = system("python -c 'import sys; sys.stdout.write(str(sys.version_info[0]))'")
-        if v:shell_error == 0 && len(s:def_py)
-            let g:jedi#force_py_version = s:def_py
-        else
-            if !exists("g:jedi#squelch_py_warning")
-                echomsg "Error: jedi-vim failed to get Python version from sys.version_info: " . s:def_py
-            endif
+if g:jedi#force_py_version == 'auto'
+    " Get default python version from interpreter in $PATH.
+    let s:def_py = system("python -c 'import sys; sys.stdout.write(str(sys.version_info[0]))'")
+    if v:shell_error == 0 && len(s:def_py)
+        let g:jedi#force_py_version = s:def_py
+    else
+        if !exists("g:jedi#squelch_py_warning")
+            echomsg "Error: jedi-vim failed to get Python version from sys.version_info: " . s:def_py
+            echomsg "Falling back to version 2."
         endif
+        let g:jedi#force_py_version = 2
     endif
-    return g:jedi#force_py_version
-endfunction
 
-" NOTE: nvim usually has both python providers. Skipping the `has` check
-" avoids starting both of them.
-if has('nvim') || (has('python') && has('python3'))
-    " Use default python with Jedi.
-    call jedi#force_py_version(jedi#get_force_py_version())
-elseif has('python')
-    command! -nargs=1 Python python <args>
-    execute 'pyfile '.s:script_path.'/initialize.py'
-elseif has('python3')
-    command! -nargs=1 Python python3 <args>
-    execute 'py3file '.s:script_path.'/initialize.py'
+    if has('nvim') || (has('python') && has('python3'))
+        " Neovim usually has both python providers. Skipping the `has` check
+        " avoids starting both of them.
+        call jedi#force_py_version(g:jedi#force_py_version)
+    elseif has('python')
+        command! -nargs=1 Python python <args>
+        execute 'pyfile '.s:script_path.'/initialize.py'
+    elseif has('python3')
+        command! -nargs=1 Python python3 <args>
+        execute 'py3file '.s:script_path.'/initialize.py'
+    else
+        if !exists("g:jedi#squelch_py_warning")
+            echomsg "Error: jedi-vim requires vim compiled with +python"
+        endif
+        finish
+    end
 else
-    if !exists("g:jedi#squelch_py_warning")
-        echomsg "Error: jedi-vim requires vim compiled with +python"
-    endif
-    finish
-endif
+    call jedi#force_py_version(g:jedi#force_py_version)
+end
 
 
 "Python jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout, speed=True, warnings=False, notices=False)

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -309,7 +309,7 @@ let s:settings = {
     \ 'popup_select_first': 1,
     \ 'quickfix_window_height': 10,
     \ 'completions_enabled': 1,
-    \ 'force_py_version': 2
+    \ 'force_py_version': "'auto'"
 \ }
 
 
@@ -337,8 +337,24 @@ call s:init()
 
 let s:script_path = fnameescape(expand('<sfile>:p:h:h'))
 
+" Get g:jedi#force_py_version, handling "auto" on first call.
+function! jedi#get_force_py_version()
+    if g:jedi#force_py_version == 'auto'
+        let s:def_py = system("python -c 'import sys; sys.stdout.write(str(sys.version_info[0]))'")
+        if v:shell_error == 0 && len(s:def_py)
+            let g:jedi#force_py_version = s:def_py
+        else
+            if !exists("g:jedi#squelch_py_warning")
+                echomsg "Error: jedi-vim failed to get Python version from sys.version_info: " . s:def_py
+            endif
+        endif
+    endif
+    return g:jedi#force_py_version
+endfunction
+
 if has('python') && has('python3')
-    call jedi#force_py_version(g:jedi#force_py_version)
+    " Use default python with Jedi.
+    call jedi#force_py_version(jedi#get_force_py_version())
 elseif has('python')
     command! -nargs=1 Python python <args>
     execute 'pyfile '.s:script_path.'/initialize.py'

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -256,13 +256,19 @@ endfunction
 
 function! jedi#force_py_version(py_version)
     let g:jedi#force_py_version = a:py_version
-    if g:jedi#force_py_version == 2
-        command! -nargs=1 Python python <args>
-        execute 'pyfile '.s:script_path.'/initialize.py'
-    elseif g:jedi#force_py_version == 3
-        command! -nargs=1 Python python3 <args>
-        execute 'py3file '.s:script_path.'/initialize.py'
-    endif
+    try
+        if g:jedi#force_py_version == 2
+            command! -nargs=1 Python python <args>
+            execute 'pyfile '.s:script_path.'/initialize.py'
+        elseif g:jedi#force_py_version == 3
+            command! -nargs=1 Python python3 <args>
+            execute 'py3file '.s:script_path.'/initialize.py'
+        endif
+    catch
+        if !exists("g:jedi#squelch_py_warning")
+            echom "jedi#force_py_version failed: " . v:exception
+        endif
+    endtry
 endfunction
 
 

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -462,7 +462,7 @@ or set directly using this function, which has the same name as the variable:
 Function: `jedi#force_py_version(py_version)`
 
 Options: 2 or 3
-Default: 2
+Default: "auto" (will use sys.version_info from "python" in your $PATH)
 
 ==============================================================================
 7. Testing				*jedi-vim-testing*

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -1,4 +1,4 @@
-if !has('python') && !has('python3')
+if !jedi#init_python()
     finish
 endif
 " ------------------------------------------------------------------------


### PR DESCRIPTION
This PR started with `"auto"` support for `g:jedi#force_py_version`, but then I've refactored it and improved the init handling altogether.

"auto" is meant to pick up the correct Python version from your Virtualenv etc.

Please let me know what you think about this PR altogether and I can then cleanup/squash the commits.