### PR TITLE
Use "echohl WarningMsg" instead of "echoerr" in no_jedi_warning

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 def no_jedi_warning():
-    vim.command('echoerr "Please install Jedi if you want to use jedi_vim."')
+    vim.command('echohl WarningMsg | echom "Please install Jedi if you want to use jedi_vim." | echohl None')
 
 
 def echo_highlight(msg):


### PR DESCRIPTION
`echoerr` causes Vim to throw an error, but like the function name
indicates, this is only a warning.