### PR TITLE
Fix popup-on-dot completion: use <C-p> to deselect the first entry

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -240,15 +240,22 @@ function! jedi#complete_string(is_popup_on_dot)
     if pumvisible() && !a:is_popup_on_dot
         return "\<C-n>"
     else
-        return "\<C-x>\<C-o>\<C-r>=jedi#complete_opened()\<CR>"
+        return "\<C-x>\<C-o>\<C-r>=jedi#complete_opened(".a:is_popup_on_dot.")\<CR>"
     endif
 endfunction
 
 
-function! jedi#complete_opened()
-    if pumvisible() && g:jedi#popup_select_first && stridx(&completeopt, 'longest') > -1
-        " only go down if it is visible, user-enabled and the longest option is set
-        return "\<Down>"
+function! jedi#complete_opened(is_popup_on_dot)
+    if pumvisible()
+        if a:is_popup_on_dot
+            " Prevent completion of the first entry with dot completion.
+            return "\<C-p>"
+        endif
+        " Only go down if it is visible, user-enabled and the longest
+        " option is set.
+        if g:jedi#popup_select_first && stridx(&completeopt, 'longest') > -1
+            return "\<Down>"
+        endif
     endif
     return ""
 endfunction


### PR DESCRIPTION
Without this, the `<C-x><C-o>` triggered by jedi-vim would cause the first
match to be inserted (and selected).  When using completopt=longest,
this was less so an issue.