### PR TITLE
Select mode mapping for completion trigger

### DIFF
--- a/after/ftplugin/python/jedi.vim
+++ b/after/ftplugin/python/jedi.vim
@@ -10,8 +10,8 @@ if g:jedi#auto_initialization
 
         " map ctrl+space for autocompletion
         if g:jedi#completions_command == "<C-Space>"
-            " in terminals, <C-Space> sometimes equals <Nul>
-            inoremap <expr> <Nul> jedi#complete_string(0)
+            " In terminals, <C-Space> sometimes equals <Nul>.
+            imap <buffer> <Nul> <C-Space>
         endif
         if g:jedi#completions_command != ""
             execute "inoremap <expr> <buffer> ".g:jedi#completions_command." jedi#complete_string(0)"

--- a/after/ftplugin/python/jedi.vim
+++ b/after/ftplugin/python/jedi.vim
@@ -12,9 +12,12 @@ if g:jedi#auto_initialization
         if g:jedi#completions_command == "<C-Space>"
             " In terminals, <C-Space> sometimes equals <Nul>.
             imap <buffer> <Nul> <C-Space>
+            smap <buffer> <Nul> <C-Space>
         endif
         if g:jedi#completions_command != ""
             execute "inoremap <expr> <buffer> ".g:jedi#completions_command." jedi#complete_string(0)"
+            " A separate mapping for select mode: deletes and completes.
+            execute "snoremap <expr> <buffer> ".g:jedi#completions_command." '\<C-g>c'.jedi#complete_string(0)"
         endif
     endif
 endif


### PR DESCRIPTION
This deletes the selection (by going to visual mode, and "c"), and then
triggers the completion.

This is useful with e.g. UltiSnips, when you want to start completion
with an expanded snippet argument selected.

Ref: https://github.com/davidhalter/jedi-vim/pull/339#issuecomment-97612632