### PR TITLE
auto-config: set completeopt only if it's the default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ you disable the auto-initialization in your ``.vimrc``:
     let g:jedi#auto_initialization = 0
 
 There are also some VIM options (like ``completeopt`` and key defaults) which
-are automatically initialized, but you can change all of them:
+are automatically initialized, but you can skip this:
 
 .. code-block:: vim
 

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -336,9 +336,11 @@ Default: 1 (Perform automatic initialization)
 ------------------------------------------------------------------------------
 6.2. `g:jedi#auto_vim_configuration`	*g:jedi#auto_vim_configuration*
 
-Jedi-vim sets 'completeopt' to `menuone,longest,preview` by default. It also
-remaps <Ctrl-C> to <Esc> in insert mode. If you want to keep your own
-configuration, disable this setting.
+Jedi-vim sets 'completeopt' to `menuone,longest,preview` by default, if
+'completeopt' is not changed from Vim's default.
+It also remaps <Ctrl-C> to <Esc> in insert mode.
+
+If you want to keep your own configuration, disable this setting.
 
 Options: 0 or 1
 Default: 1 (Set 'completeopt' and mapping as described above)

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -38,10 +38,3 @@ if g:jedi#auto_initialization
         autocmd InsertLeave <buffer> if pumvisible() == 0|pclose|endif
     endif
 endif
-
-if g:jedi#auto_vim_configuration
-    setlocal completeopt=menuone,longest,preview
-    if len(mapcheck('<C-c>', 'i')) == 0
-        inoremap <C-c> <ESC>
-    endif
-endif

--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -12,6 +12,19 @@ if !exists("g:jedi#auto_vim_configuration") || g:jedi#auto_vim_configuration
 
     " jedi-vim really needs, otherwise jedi-vim cannot start.
     filetype plugin on
+
+    " Change completeopt, but only if it has Vim's default value.
+    let s:save_completeopt=&completeopt
+    set completeopt&
+    let s:default_completeopt=&completeopt
+    let &completeopt=s:save_completeopt
+    if s:default_completeopt == &completeopt
+        set completeopt=menuone,longest,preview
+    endif
+
+    if len(mapcheck('<C-c>', 'i')) == 0
+        inoremap <C-c> <ESC>
+    endif
 endif
 
 " Pyimport command


### PR DESCRIPTION
The setting is also moved from "ftplugin" to "plugin", which allows for
easier customization, e.g. via a FileType plugin.

Ref: https://github.com/davidhalter/jedi-vim/issues/374#issuecomment-97621368