### PR TITLE
Change default for show_call_signatures to 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ can improve the integrity of Vim's undo history.
 
 .. code-block:: vim
 
-    let g:jedi#show_call_signatures = "1"
+    let g:jedi#show_call_signatures = "2"
 
 Here are a few more defaults for actions, read the docs (``:help jedi-vim``) to
 get more information. If you set them to ``""``, they are not assigned.

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -394,7 +394,7 @@ be disabled by setting this option to 0. Setting this option to 2 shows call
 signatures in the command line instead of a popup window.
 
 Options: 0, 1, or 2
-Default: 1 (Show call signatures window)
+Default: 2 (Show call signatures in command line)
 
 Note: 'showmode' must be disabled for command line call signatures to be
 visible.


### PR DESCRIPTION
This appears to be less error-prone.

E.g. with things like indenting plugins (https://github.com/hynek/vim-python-pep8-indent/pull/41).