### PR TITLE
WIP: improve performance with call signatures

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -286,8 +286,13 @@ def show_documentation():
     return True
 
 
+last_displayed_signatures = None
+
 @catch_and_print_exceptions
 def clear_call_signatures():
+    global last_displayed_signatures
+    last_displayed_signatures = None
+
     # Check if using command line call signatures
     if vim_eval("g:jedi#show_call_signatures") == '2':
         vim_command('echo ""')
@@ -309,8 +314,6 @@ def clear_call_signatures():
             line = line[:match.start()] + match.group(2) + after
             vim.current.buffer[i] = line
     vim.current.window.cursor = cursor
-
-last_displayed_signatures = None
 
 @_check_jedi_availability(show_error=False)
 @catch_and_print_exceptions

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -310,6 +310,7 @@ def clear_call_signatures():
             vim.current.buffer[i] = line
     vim.current.window.cursor = cursor
 
+last_displayed_signatures = None
 
 @_check_jedi_availability(show_error=False)
 @catch_and_print_exceptions
@@ -319,13 +320,20 @@ def show_call_signatures(signatures=()):
 
     if signatures == ():
         signatures = get_script().call_signatures()
-    clear_call_signatures()
 
     if not signatures:
+        clear_call_signatures()
         return
 
     if vim_eval("g:jedi#show_call_signatures") == '2':
+        global last_displayed_signatures
+        if str(signatures) == str(last_displayed_signatures):
+            return
+        last_displayed_signatures = signatures
+        clear_call_signatures()
         return cmdline_call_signatures(signatures)
+
+    clear_call_signatures()
 
     for i, signature in enumerate(signatures):
         line, column = signature.bracket_start


### PR DESCRIPTION
When using call signatures and moving around in insert mode, the performance is pretty bad.

I can see some potential in improving this.

This PR is work-in-progress and currently it just skips calling `cmdline_call_signatures`, if the signatures have not changed.

@davidhalter 
NOTE: it uses `str(...)` for comparison, because otherwise the signatures were not being considered to be equal.. a Jedi issue?

This first commit avoids the flickering in the cmdline, but still slows down moving around in insert mode.

Further ideas: we could only call out to Jedi in case the syntax name under the cursor has been changed.
