### PR TITLE
Fix ValueError with cmdline call signatures

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -411,8 +411,9 @@ def cmdline_call_signatures(signatures):
 
     try:
         index = [s.index for s in signatures if isinstance(s.index, int)][0]
-        left = text.index(params[index])
-        right = left + len(params[index])
+        escaped_param = params[index].replace(r'\n', r'\\n')
+        left = text.index(escaped_param)
+        right = left + len(escaped_param)
         vim_command('                      echon "%s" | '
                     'echohl Function     | echon "%s" | '
                     'echohl None         | echon "("  | '


### PR DESCRIPTION
Commit 8016665 (PR #360) escaped the newlines in `text`, which requires to use the
escaped version with `text.index` and `len`, too.

This fixes the following error:

    Traceback (most recent call last):
      File "…/jedi/jedi_vim.py", line 110, in wrapper
        return func(*args, **kwargs)
      File "…/jedi/jedi_vim.py", line 414, in cmdline_call_signatures
        left = text.index(params[index])
    ValueError: substring not found

/cc @wilywampa (author of PR #360)