### PR TITLE
Delayed call signatures

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -26,6 +26,7 @@ let s:default_settings = {
     \ 'popup_on_dot': 1,
     \ 'documentation_command': "'K'",
     \ 'show_call_signatures': 1,
+    \ 'show_call_signatures_delay': 500,
     \ 'call_signature_escape': "'=`='",
     \ 'auto_close_doc': 1,
     \ 'max_doc_height': 30,
@@ -373,7 +374,17 @@ function! jedi#configure_call_signatures()
         autocmd InsertEnter <buffer> let g:jedi#first_col = s:save_first_col()
     endif
     autocmd InsertLeave <buffer> PythonJedi jedi_vim.clear_call_signatures()
-    autocmd CursorMovedI <buffer> PythonJedi jedi_vim.show_call_signatures()
+    if g:jedi#show_call_signatures_delay > 0
+        autocmd InsertEnter <buffer> let b:_jedi_orig_updatetime = &updatetime
+                    \ | let &updatetime = g:jedi#show_call_signatures_delay
+        autocmd InsertLeave <buffer> if exists('b:_jedi_orig_updatetime')
+                    \ |   let &updatetime = b:_jedi_orig_updatetime
+                    \ |   unlet b:_jedi_orig_updatetime
+                    \ | endif
+        autocmd CursorHoldI <buffer> PythonJedi jedi_vim.show_call_signatures()
+    else
+        autocmd CursorMovedI <buffer> PythonJedi jedi_vim.show_call_signatures()
+    endif
     augroup END
 endfunction
 

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -367,11 +367,14 @@ endfunc
 
 
 function! jedi#configure_call_signatures()
+    augroup jedi_call_signatures
+    au!
     if g:jedi#show_call_signatures == 2  " Command line call signatures
         autocmd InsertEnter <buffer> let g:jedi#first_col = s:save_first_col()
     endif
     autocmd InsertLeave <buffer> PythonJedi jedi_vim.clear_call_signatures()
     autocmd CursorMovedI <buffer> PythonJedi jedi_vim.show_call_signatures()
+    augroup END
 endfunction
 
 

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -367,13 +367,47 @@ function! jedi#do_popup_on_dot_in_highlight()
 endfunc
 
 
+let s:show_call_signatures_last = [0, 0, '']
+function! jedi#show_call_signatures()
+    let [line, col] = [line('.'), col('.')]
+    let curline = getline(line)
+    let reload_signatures = 1
+
+    " Caching.  On the same line only.
+    if line == s:show_call_signatures_last[0]
+        " Check if the number of commas before or after the cursor has
+        " not changed: this means that the argument position was not
+        " changed and we can skip repainting.
+        let prevcol = s:show_call_signatures_last[1]
+        let prevline = s:show_call_signatures_last[2]
+        if substitute(curline[:col-2], '[^,]', '', 'g')
+                    \ == substitute(prevline[:prevcol-2], '[^,]', '', 'g')
+                    \ && substitute(curline[(col-2):], '[^,]', '', 'g')
+                    \ == substitute(prevline[(prevcol-2):], '[^,]', '', 'g')
+            let reload_signatures = 0
+        endif
+    endif
+    let s:show_call_signatures_last = [line, col, curline]
+
+    if reload_signatures
+        PythonJedi jedi_vim.show_call_signatures()
+    endif
+endfunction
+
+
+function! jedi#clear_call_signatures()
+    let s:show_call_signatures_last = [0, 0, '']
+    PythonJedi jedi_vim.clear_call_signatures()
+endfunction
+
+
 function! jedi#configure_call_signatures()
     augroup jedi_call_signatures
     au!
     if g:jedi#show_call_signatures == 2  " Command line call signatures
         autocmd InsertEnter <buffer> let g:jedi#first_col = s:save_first_col()
     endif
-    autocmd InsertLeave <buffer> PythonJedi jedi_vim.clear_call_signatures()
+    autocmd InsertLeave <buffer> call jedi#clear_call_signatures()
     if g:jedi#show_call_signatures_delay > 0
         autocmd InsertEnter <buffer> let b:_jedi_orig_updatetime = &updatetime
                     \ | let &updatetime = g:jedi#show_call_signatures_delay
@@ -381,9 +415,9 @@ function! jedi#configure_call_signatures()
                     \ |   let &updatetime = b:_jedi_orig_updatetime
                     \ |   unlet b:_jedi_orig_updatetime
                     \ | endif
-        autocmd CursorHoldI <buffer> PythonJedi jedi_vim.show_call_signatures()
+        autocmd CursorHoldI <buffer> call jedi#show_call_signatures()
     else
-        autocmd CursorMovedI <buffer> PythonJedi jedi_vim.show_call_signatures()
+        autocmd CursorMovedI <buffer> call jedi#show_call_signatures()
     endif
     augroup END
 endfunction

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -36,12 +36,13 @@ Contents				*jedi-vim-contents*
     6.4. popup_select_first		|g:jedi#popup_select_first|
     6.5. auto_close_doc			|g:jedi#auto_close_doc|
     6.6. show_call_signatures		|g:jedi#show_call_signatures|
-    6.7. use_tabs_not_buffers		|g:jedi#use_tabs_not_buffers|
-    6.8. squelch_py_warning		|g:jedi#squelch_py_warning|
-    6.9. completions_enabled		|g:jedi#completions_enabled|
-    6.10. use_splits_not_buffers	|g:jedi#use_splits_not_buffers|
-    6.11. force_py_version              |g:jedi#force_py_version|
-    6.12. smart_auto_mappings           |g:jedi#smart_auto_mappings|
+    6.7. show_call_signatures_delay	|g:jedi#show_call_signatures_delay|
+    6.8. use_tabs_not_buffers		|g:jedi#use_tabs_not_buffers|
+    6.9. squelch_py_warning		|g:jedi#squelch_py_warning|
+    6.10. completions_enabled		|g:jedi#completions_enabled|
+    6.11. use_splits_not_buffers	|g:jedi#use_splits_not_buffers|
+    6.12. force_py_version              |g:jedi#force_py_version|
+    6.13. smart_auto_mappings           |g:jedi#smart_auto_mappings|
 7. Testing				|jedi-vim-testing|
 8. Contributing				|jedi-vim-contributing|
 9. License				|jedi-vim-license|
@@ -422,7 +423,17 @@ manually by calling a function in your configuration file: >
     call jedi#configure_call_signatures()
 
 ------------------------------------------------------------------------------
-6.7. `g:jedi#use_tabs_not_buffers`	*g:jedi#use_tabs_not_buffers*
+6.7. `g:jedi#show_call_signatures_delay`  *g:jedi#show_call_signatures_delay*
+
+The delay to be used with |g:jedi#show_call_signatures|.  If it is greater
+than 0 it will use Vim's |CursorHoldI| event instead of |CursorMovedI|.
+It will temporarily set Vim's |'updatetime'| option during insert mode.
+
+Options: delay in milliseconds
+Default: 500
+
+------------------------------------------------------------------------------
+6.8. `g:jedi#use_tabs_not_buffers`	*g:jedi#use_tabs_not_buffers*
 
 You can make jedi-vim open a new tab if you use the "go to", "show
 definition", or "related names" commands. When you leave this at the default
@@ -432,7 +443,7 @@ Options: 0 or 1
 Default: 0 (Command output is put in a new tab)
 
 ------------------------------------------------------------------------------
-6.8. `g:jedi#squelch_py_warning`	*g:jedi#squelch_py_warning*
+6.9. `g:jedi#squelch_py_warning`	*g:jedi#squelch_py_warning*
 
 When Vim has not been compiled with +python, jedi-vim shows a warning to that
 effect and aborts loading itself. Set this to 1 to suppress that warning.
@@ -441,7 +452,7 @@ Options: 0 or 1
 Default: 0 (Warning is shown)
 
 ------------------------------------------------------------------------------
-6.9. `g:jedi#completions_enabled`	*g:jedi#completions_enabled*
+6.10. `g:jedi#completions_enabled`	*g:jedi#completions_enabled*
 
 If you don't want Jedi completion, but all the other features, you can disable
 it in favor of another completion engine (that probably also uses Jedi, like
@@ -451,7 +462,7 @@ Options: 0 or 1
 Default: 1
 
 ------------------------------------------------------------------------------
-6.10. `g:jedi#use_splits_not_buffers`	*g:jedi#use_splits_not_buffers*
+6.11. `g:jedi#use_splits_not_buffers`	*g:jedi#use_splits_not_buffers*
 
 If you want to open new split for "go to", you could set this option to the
 direction which you want to open a split with.
@@ -465,7 +476,7 @@ means that if the window is big enough it will be split vertically but if it is
 small a horizontal split happens.
 
 ------------------------------------------------------------------------------
-6.11. `g:jedi#force_py_version`                *g:jedi#force_py_version*
+6.12. `g:jedi#force_py_version`                *g:jedi#force_py_version*
 
 If you have installed both python 2 and python 3, you can force which one jedi
 should use by setting this variable. It forces the internal Vim command, which
@@ -483,7 +494,7 @@ Function: `jedi#force_py_version(py_version)`
 Options: 2 or 3
 Default: "auto" (will use sys.version_info from "python" in your $PATH)
 ------------------------------------------------------------------------------
-6.12. `g:jedi#smart_auto_mappings`	            *g:jedi#smart_auto_mappings*
+6.13. `g:jedi#smart_auto_mappings`	            *g:jedi#smart_auto_mappings*
 
 When you start typing `from module.name<space>` jedi-vim automatically
 adds the "import" statement and displays the autocomplete popup.

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -50,7 +50,7 @@ describe 'signatures'
         redir => msg
         doautocmd InsertLeave 
         redir END
-        Expect msg == "\n\n"
+        Expect msg == "\n"
     end
 
     it 'command line no signature'


### PR DESCRIPTION
Add `show_call_signatures_delay` option

This will use CursorHoldI instead of CursorMovedI for displaying call
signatures, with a delay of 500ms by default.

This greatly enhances the experience with slow call signatures while typing
(depending on how fast Jedi is for the given context).

Ref: #420.

It just came to my mind that this addresses (my) main issues with the call signatures, which can be nasty when `Jedi` is slow on some more complex context while typing.