### PR TITLE
s:init_python() fails on Windows

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -46,6 +46,7 @@ Talha Ahmed (@talha81) <talha.ahmed@gmail.com>
 Matthew Tylee Atkinson (@matatk)
 Pedro Ferrari (@petobens)
 Dave Honneffer (@pearofducks)
+Daisuke Suzuki (@daisuzu) <daisuzu@gmail.com>
 
 
 @something are github user names.

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -70,7 +70,7 @@ function! s:init_python()
         " avoids starting both of them.
 
         " Get default python version from interpreter in $PATH.
-        let s:def_py = system("python -c 'import sys; sys.stdout.write(str(sys.version_info[0]))'")
+        let s:def_py = system('python -c "import sys; sys.stdout.write(str(sys.version_info[0]))"')
         if v:shell_error != 0 || !len(s:def_py)
             if !exists("g:jedi#squelch_py_warning")
                 echohl WarningMsg


### PR DESCRIPTION
Try to get the Python version from PATH on Windows,
fails to execute `system()` and exception occurs in vim.

Use double quotes to the shell argument, it works.