### PR TITLE
Add jedi#reinit_python

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -101,6 +101,12 @@ function! s:init_python()
 endfunction
 
 
+function! jedi#reinit_python()
+    unlet! s:_init_python
+    call jedi#init_python()
+endfunction
+
+
 function! jedi#init_python()
     if !exists('s:_init_python')
         try


### PR DESCRIPTION
This is meant to be used in case you want to re-init the Python version
used by jedi-vim, without restarting Vim.

I had this laying around.. it might be better to just export
`s:init_python` as `jedi#init_python`?!