### PR TITLE
Add JediDebugInfo command: display used Python version

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -118,13 +118,16 @@ function! jedi#init_python()
 endfunction
 
 
+let s:python_version = 'null'
 function! jedi#setup_py_version(py_version)
     if a:py_version == 2
         let cmd_init = 'pyfile'
         let cmd_exec = 'python'
+        let s:python_version = 2
     elseif a:py_version == 3
         let cmd_init = 'py3file'
         let cmd_exec = 'python3'
+        let s:python_version = 3
     else
         throw "jedi#setup_py_version: invalid py_version: ".a:py_version
     endif
@@ -136,6 +139,11 @@ function! jedi#setup_py_version(py_version)
     catch
         throw "jedi#setup_py_version: ".v:exception
     endtry
+endfunction
+
+
+function! jedi#debug_info()
+    echom "Using Python version:" s:python_version
 endfunction
 
 

--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -30,4 +30,6 @@ endif
 " Pyimport command
 command! -nargs=1 -complete=custom,jedi#py_import_completions Pyimport :call jedi#py_import(<q-args>)
 
+command! -nargs=0 JediDebugInfo call jedi#debug_info()
+
 " vim: set et ts=4:


### PR DESCRIPTION
This command is meant to come in handy to debug problems with jedi-vim.
For now, it will display the Python version that jedi-vim is using.