### PR TITLE
Add g:jedi#use_tag_stack feature for jedi#goto()

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -34,7 +34,8 @@ let s:default_settings = {
     \ 'quickfix_window_height': 10,
     \ 'completions_enabled': 1,
     \ 'force_py_version': "'auto'",
-    \ 'smart_auto_mappings': 1
+    \ 'smart_auto_mappings': 1,
+    \ 'use_tag_stack': 1
 \ }
 
 for [s:key, s:val] in items(s:deprecations)

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -511,7 +511,9 @@ Default: 1 (enabled by default)
 6.14. `g:jedi#use_tag_stack`			*g:jedi#use_tag_stack*
 
 Write results of |jedi#goto| to a temporary file and use the *:tjump* command
-to enable full *tagstack* functionality.
+to enable full |tagstack| functionality. Use of the tag stack allows
+returning to the usage of a function with CTRL-T after exploring the
+definition with arbitrary changes to the |jumplist|.
 
 Options: 0 or 1
 Default: 1 (enabled by default)

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -43,6 +43,7 @@ Contents				*jedi-vim-contents*
     6.11. use_splits_not_buffers	|g:jedi#use_splits_not_buffers|
     6.12. force_py_version              |g:jedi#force_py_version|
     6.13. smart_auto_mappings           |g:jedi#smart_auto_mappings|
+    6.14. use_tag_stack                 |g:jedi#use_tag_stack|
 7. Testing				|jedi-vim-testing|
 8. Contributing				|jedi-vim-contributing|
 9. License				|jedi-vim-license|
@@ -502,6 +503,15 @@ adds the "import" statement and displays the autocomplete popup.
 This option can be disabled in the .vimrc:
 
 `let g:jedi#smart_auto_mappings = 0`
+
+Options: 0 or 1
+Default: 1 (enabled by default)
+
+------------------------------------------------------------------------------
+6.14. `g:jedi#use_tag_stack`			*g:jedi#use_tag_stack*
+
+Write results of |jedi#goto| to a temporary file and use the *:tjump* command
+to enable full *tagstack* functionality.
 
 Options: 0 or 1
 Default: 1 (enabled by default)

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -7,7 +7,6 @@ import traceback  # for exception output
 import re
 import os
 import sys
-import tempfile
 import string
 import random
 from shlex import split as shsplit
@@ -247,7 +246,7 @@ def goto(mode="goto", no_output=False):
                                    % d.desc_with_module)
             else:
                 if vim_eval('g:jedi#use_tag_stack') == '1':
-                    with tempfile.NamedTemporaryFile('w') as f:
+                    with open(vim_eval('tempname()'), 'w') as f:
                         tagname = d.name
                         while vim_eval('taglist("^%s$")' % tagname) != []:
                             tagname = d.name + ' ' + ''.join(

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -601,8 +601,6 @@ def new_buffer(path, options='', using_tagstack=False):
             print('g:jedi#use_splits_not_buffers value is not correct, valid options are: %s' % ','.join(split_options.keys()))
         else:
             vim_command(split_options[user_split_option] + " %s" % path)
-    elif using_tagstack:
-        return True
     else:
         if vim_eval("!&hidden && &modified") == '1':
             if vim_eval("bufname('%')") is None:
@@ -610,6 +608,8 @@ def new_buffer(path, options='', using_tagstack=False):
                 return False
             else:
                 vim_command('w')
+        if using_tagstack:
+            return True
         vim_command('edit %s %s' % (options, escape_file_path(path)))
     # sometimes syntax is being disabled and the filetype not set.
     if vim_eval('!exists("g:syntax_on")') == '1':


### PR DESCRIPTION
I added a feature to use the tag stack instead of just the jump list. This is really convenient where you jump to a definition, then move around with all kinds of jumps to investigate whatever you jumped to, then can instantly jump back to the place `goto()` was called from with `<C-t>` instead of repeating `<C-o>` a bunch.