### PR TITLE
Truncate long command line call signatures

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -398,9 +398,10 @@ def cmdline_call_signatures(signatures):
         params = get_params(signatures[0])
     text = ', '.join(params).replace('"', '\\"').replace(r'\n', r'\\n')
 
-    # Allow 12 characters for ruler/showcmd - setting noruler/noshowcmd
-    # here causes incorrect undo history
-    max_msg_len = int(vim_eval('&columns')) - 12
+    # Allow 12 characters for showcmd plus 18 for ruler - setting
+    # noruler/noshowcmd here causes incorrect undo history
+    max_msg_len = int(vim_eval('&columns')) - (
+        30 if int(vim_eval('&ruler')) else 12)
     max_num_spaces = (max_msg_len - len(signatures[0].call_name)
                       - len(text) - 2)  # 2 accounts for parentheses
     if max_num_spaces < 0:

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The Python parts of the Jedi library for VIM. It is mostly about communicating
 with VIM.
@@ -16,7 +17,10 @@ except ImportError:
 
 is_py3 = sys.version_info[0] >= 3
 if is_py3:
+    ELLIPSIS = "…"
     unicode = str
+else:
+    ELLIPSIS = u"…"
 
 
 class PythonToVimStr(unicode):
@@ -419,22 +423,22 @@ def cmdline_call_signatures(signatures):
         return
     elif index is None:
         pass
-    elif max_msg_len < len('...'):
+    elif max_msg_len < len(ELLIPSIS):
         return
     else:
         left = escape(', '.join(params[:index]))
         center = escape(params[index])
         right = escape(', '.join(params[index + 1:]))
         while too_long():
-            if left and left != '...':
-                left = '...'
+            if left and left != ELLIPSIS:
+                left = ELLIPSIS
                 continue
-            if right and right != '...':
-                right = '...'
+            if right and right != ELLIPSIS:
+                right = ELLIPSIS
                 continue
-            if (left or right) and center != '...':
+            if (left or right) and center != ELLIPSIS:
                 left = right = None
-                center = '...'
+                center = ELLIPSIS
                 continue
             if too_long():
                 # Should never reach here

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -53,6 +53,39 @@ describe 'signatures'
         Expect msg == "\n"
     end
 
+    it 'command line truncation'
+        let g:jedi#show_call_signatures = 2
+        call jedi#configure_call_signatures()
+
+        function! Signature()
+            redir => msg
+            Python jedi_vim.show_call_signatures()
+            redir END
+            return msg
+        endfunction
+
+        let funcname = repeat('a', &columns - 30)
+        put = 'def '.funcname.'(arg1, arg2, arg3, a, b, c):'
+        put = '    pass'
+        execute "normal o".funcname."( "
+        Expect Signature() == "\n".funcname."(arg1, ...)"
+
+        normal sarg1, 
+        Expect Signature() == "\n".funcname."(..., arg2, ...)"
+
+        normal sarg2, arg3, 
+        Expect Signature() == "\n".funcname."(..., a, b, c)"
+
+        normal sa, b, 
+        Expect Signature() == "\n".funcname."(..., c)"
+
+        g/^/d
+        put = 'def '.funcname.'('.repeat('b', 20).', arg2):'
+        put = '    pass'
+        execute "normal o".funcname."( "
+        Expect Signature() == "\n".funcname."(...)"
+    end
+
     it 'command line no signature'
         let g:jedi#show_call_signatures = 2
         call jedi#configure_call_signatures()

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -68,22 +68,22 @@ describe 'signatures'
         put = 'def '.funcname.'(arg1, arg2, arg3, a, b, c):'
         put = '    pass'
         execute "normal o".funcname."( "
-        Expect Signature() == "\n".funcname."(arg1, ...)"
+        Expect Signature() == "\n".funcname."(arg1, …)"
 
         normal sarg1, 
-        Expect Signature() == "\n".funcname."(..., arg2, ...)"
+        Expect Signature() == "\n".funcname."(…, arg2, …)"
 
         normal sarg2, arg3, 
-        Expect Signature() == "\n".funcname."(..., a, b, c)"
+        Expect Signature() == "\n".funcname."(…, a, b, c)"
 
         normal sa, b, 
-        Expect Signature() == "\n".funcname."(..., c)"
+        Expect Signature() == "\n".funcname."(…, c)"
 
         g/^/d
         put = 'def '.funcname.'('.repeat('b', 20).', arg2):'
         put = '    pass'
         execute "normal o".funcname."( "
-        Expect Signature() == "\n".funcname."(...)"
+        Expect Signature() == "\n".funcname."(…)"
     end
 
     it 'command line no signature'


### PR DESCRIPTION
Truncate command line call signature as described in https://github.com/davidhalter/jedi-vim/issues/474 when the full signature is too long to display.