### PR TITLE
Handle parenthesis with show_call_signatures' cache

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -376,15 +376,15 @@ function! jedi#show_call_signatures()
 
     " Caching.  On the same line only.
     if line == s:show_call_signatures_last[0]
-        " Check if the number of commas before or after the cursor has
-        " not changed: this means that the argument position was not
-        " changed and we can skip repainting.
+        " Check if the number of commas and parenthesis before or after the
+        " cursor has not changed since the last call, which means that the
+        " argument position was not changed and we can skip repainting.
         let prevcol = s:show_call_signatures_last[1]
         let prevline = s:show_call_signatures_last[2]
-        if substitute(curline[:col-2], '[^,]', '', 'g')
-                    \ == substitute(prevline[:prevcol-2], '[^,]', '', 'g')
-                    \ && substitute(curline[(col-2):], '[^,]', '', 'g')
-                    \ == substitute(prevline[(prevcol-2):], '[^,]', '', 'g')
+        if substitute(curline[:col-2], '[^,()]', '', 'g')
+                    \ == substitute(prevline[:prevcol-2], '[^,()]', '', 'g')
+                    \ && substitute(curline[(col-2):], '[^,()]', '', 'g')
+                    \ == substitute(prevline[(prevcol-2):], '[^,()]', '', 'g')
             let reload_signatures = 0
         endif
     endif
@@ -396,6 +396,12 @@ function! jedi#show_call_signatures()
 endfunction
 
 
+function! jedi#clear_call_signatures()
+    let s:show_call_signatures_last = [0, 0, '']
+    PythonJedi jedi_vim.clear_call_signatures()
+endfunction
+
+
 function! jedi#configure_call_signatures()
     augroup jedi_call_signatures
     au!
@@ -403,7 +409,7 @@ function! jedi#configure_call_signatures()
         autocmd InsertEnter <buffer> let g:jedi#first_col = s:save_first_col()
     endif
     autocmd InsertEnter <buffer> let s:show_call_signatures_last = [0, 0, '']
-    autocmd InsertLeave <buffer> PythonJedi jedi_vim.clear_call_signatures()
+    autocmd InsertLeave <buffer> call jedi#clear_call_signatures()
     if g:jedi#show_call_signatures_delay > 0
         autocmd InsertEnter <buffer> let b:_jedi_orig_updatetime = &updatetime
                     \ | let &updatetime = g:jedi#show_call_signatures_delay

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -17,8 +17,16 @@ describe 'signatures'
 
         Expect getline(1) == '=`=jedi=0, =`=   (*_*number*_*) =`=jedi=`='
 
-        doautocmd InsertLeave 
+        doautocmd InsertLeave
         Expect getline(1) == ''
+    end
+
+    it 'simple after CursorHoldI with only parenthesis'
+        noautocmd normal o
+        doautocmd CursorHoldI
+        noautocmd normal iabs( 
+        doautocmd CursorHoldI
+        Expect getline(1) == '=`=jedi=0, =`=   (*_*number*_*) =`=jedi=`='
     end
 
     it 'no signature'


### PR DESCRIPTION
After `o`, call signatures should show up after `abs(`.

Followup of https://github.com/davidhalter/jedi-vim/pull/477.