### PR TITLE
Fix #491

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -47,6 +47,7 @@ Matthew Tylee Atkinson (@matatk)
 Pedro Ferrari (@petobens)
 Daniel Hahler (@blueyed)
 Dave Honneffer (@pearofducks)
+Bagrat Aznauryan (@n9code)
 
 
 @something are github user names.

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -640,7 +640,7 @@ def new_buffer(path, options='', using_tagstack=False):
         if user_split_option not in split_options:
             print('g:jedi#use_splits_not_buffers value is not correct, valid options are: %s' % ','.join(split_options.keys()))
         else:
-            vim_command(split_options[user_split_option] + " %s" % path)
+            vim_command(split_options[user_split_option] + " %s" % escape_file_path(path))
     else:
         if vim_eval("!&hidden && &modified") == '1':
             if vim_eval("bufname('%')") is None:


### PR DESCRIPTION
Fix: If a definition file path contains a space, the open in split
     fails with an error.