### PR TITLE
Fix signatures only working in a single buffer

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -404,7 +404,7 @@ endfunction
 
 function! jedi#configure_call_signatures()
     augroup jedi_call_signatures
-    au!
+    autocmd! * <buffer>
     if g:jedi#show_call_signatures == 2  " Command line call signatures
         autocmd InsertEnter <buffer> let g:jedi#first_col = s:save_first_col()
     endif

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -21,6 +21,22 @@ describe 'signatures'
         Expect getline(1) == ''
     end
 
+    it 'multiple buffers'
+        set hidden
+        new
+        setfiletype python
+        redir => autocmds
+        autocmd jedi_call_signatures * <buffer>
+        redir END
+        Expect autocmds =~# 'jedi_call_signatures'
+        buffer #
+        redir => autocmds
+        autocmd jedi_call_signatures * <buffer>
+        redir END
+        Expect autocmds =~# 'jedi_call_signatures'
+        bd!
+    end
+
     it 'simple after CursorHoldI with only parenthesis'
         noautocmd normal o
         doautocmd CursorHoldI


### PR DESCRIPTION
The autocommands that display call signatures are reset globally any time `ftplugin/python/jedi.vim` is sourced so call signatures only work in the most recently loaded buffer. This change only resets autocommands in the current buffer. All of the `jedi_call_signatures` autocommands use `<buffer>` so that's what we want.