### PR TITLE
Fix parameters missing from command line call signatures

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -450,10 +450,12 @@ def cmdline_call_signatures(signatures):
         max_msg_len -= 18
     max_msg_len -= len(signatures[0].call_name) + 2  # call name + parentheses
 
-    if max_msg_len < 0:
+    if max_msg_len < (1 if params else 0):
         return
     elif index is None:
-        pass
+        text = escape(', '.join(params))
+        if params and len(text) > max_msg_len:
+            text = ELLIPSIS
     elif max_msg_len < len(ELLIPSIS):
         return
     else:
@@ -498,8 +500,8 @@ def cmdline_call_signatures(signatures):
     else:
         vim_command('                      echon "%s" | '
                     'echohl Function     | echon "%s" | '
-                    'echohl None         | echon "()"'
-                    % (spaces, signatures[0].call_name))
+                    'echohl None         | echon "(%s)"'
+                    % (spaces, signatures[0].call_name, text))
 
 
 @_check_jedi_availability(show_error=True)

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -75,6 +75,13 @@ describe 'signatures'
         doautocmd InsertLeave 
         redir END
         Expect msg == "\n"
+
+        normal Sdef foo(a, b): pass
+        normal ofoo(a, b, c, 
+        redir => msg
+        Python jedi_vim.show_call_signatures()
+        redir END
+        Expect msg == "\nfoo(a, b)"
     end
 
     it 'command line truncation'


### PR DESCRIPTION
Parameters (or ellipsis) should show up in call signatures even when the index of the current argument is unknown. This mostly happens when there are more arguments typed than in Jedi's idea of the signature. Currently it just shows empty parentheses even if there are parameters (this applies to command line signatures only).

PS:  When the testing fails in `test/signatures.vim` I get a `UnicodeEncodeError` from `conftest.py` ever since using the ellipsis character.