### PR TITLE
check "noselect" and "noinsert" before <C-p>

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -48,6 +48,6 @@ Pedro Ferrari (@petobens)
 Daniel Hahler (@blueyed)
 Dave Honneffer (@pearofducks)
 Bagrat Aznauryan (@n9code)
-
+Tomoyuki Kashiro (@kashiro)
 
 @something are github user names.

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -491,8 +491,10 @@ function! jedi#complete_opened(is_popup_on_dot)
             return "\<Down>"
         endif
         if a:is_popup_on_dot
-            " Prevent completion of the first entry with dot completion.
-            return "\<C-p>"
+            if &completeopt !~ '\(noinsert\|noselect\)'
+                " Prevent completion of the first entry with dot completion.
+                return "\<C-p>"
+            endif
         endif
     endif
     return ""


### PR DESCRIPTION
## outline

when I use `jedi-vim` and `neocomplete` a last option automatically select.

Please check past [issue](https://github.com/Shougo/neocomplete.vim/issues/485) to understand detail.

## related issue

- https://github.com/Shougo/neocomplete.vim/issues/485
- https://github.com/Shougo/neocomplete.vim/issues/486