### PR TITLE
[RFC] split jedi into external process

### DIFF
--- a/jedi_remote.py
+++ b/jedi_remote.py
@@ -26,15 +26,8 @@ class PoorRPC(object):
         for line in iter(self.input.readline, ''):
             data = json.loads(line)
 
-            func = getattr(self, 'func_' + data['func'])
-
-            if func is None:
-                self._write_output({
-                    'code': 'ng', 'message': 'no such func',
-                })
-                continue
-
             try:
+                func = getattr(self, 'func_' + data['func'])
                 ret = func(*data['args'], **data['kwargs'])
             except Exception as e:
                 result = {'code': 'ng', 'message': repr(e)}

--- a/jedi_remote.py
+++ b/jedi_remote.py
@@ -1,0 +1,99 @@
+import json
+import os
+import sys
+
+# add path for jedi
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'jedi'))
+
+import jedi
+
+
+class PoorRPC(object):
+    def __init__(self, input=None, output=None):
+        if input is None:
+            input = sys.stdin
+
+        if output is None:
+            output = sys.stdout
+
+        self.input = input
+        self.output = output
+
+        self.script = None
+
+    def run(self):
+        for line in iter(self.input.readline, ''):
+            data = json.loads(line)
+
+            func = getattr(self, 'func_' + data['func'])
+
+            if func is None:
+                self._write_output({
+                    'code': 'ng', 'message': 'no such func',
+                })
+                continue
+
+            try:
+                ret = func(*data['args'], **data['kwargs'])
+            except Exception as e:
+                result = {'code': 'ng', 'message': repr(e)}
+            else:
+                result = {'code': 'ok', 'return': ret}
+
+            self._write_output(result)
+
+    def _write_output(self, data):
+        self.output.write(json.dumps(data))
+        self.output.write('\n')
+        self.output.flush()
+
+    def func_set_additional_dynamic_modules(self, modules):
+        jedi.settings.additional_dynamic_modules = modules
+
+    def func_set_script(self, source, row, column, buf_path, encoding):
+        self.script = jedi.Script(source, row, column, buf_path, encoding)
+
+    def func_completions(self):
+        return [_completion2dict(c) for c in self.script.completions()]
+
+    def func_call_signatures(self):
+        return [_signiture2dict(s) for s in self.script.call_signatures()]
+
+    def func_goto_definitions(self):
+        return [_definition2dict(d) for d in self.script.goto_definitions()]
+
+    def func_goto_assignments(self):
+        return [_definition2dict(d) for d in self.script.goto_assignments()]
+
+    def func_usages(self):
+        return [_definition2dict(d) for d in self.script.usages()]
+
+
+def _completion2dict(comp):
+    d = _obj2dict(comp, 'name', 'complete', 'description')
+    d['docstring'] = comp.docstring()
+
+    return d
+
+
+def _signiture2dict(sig):
+    return _obj2dict(sig, 'bracket_start', 'params', 'index')
+
+
+def _definition2dict(defi):
+    d = _obj2dict(defi,
+                  'is_keyword', 'desc_with_module', 'module_path',
+                  'description', 'name', 'line', 'column')
+    d['in_builtin_module'] = defi.in_builtin_module()
+
+    return d
+
+
+def _obj2dict(obj, *names):
+    return {n: getattr(obj, n) for n in names}
+
+
+if __name__ == '__main__':
+    rpc = PoorRPC()
+    rpc.run()

--- a/jedi_remote.py
+++ b/jedi_remote.py
@@ -44,8 +44,8 @@ class PoorRPC(object):
     def func_set_additional_dynamic_modules(self, modules):
         jedi.settings.additional_dynamic_modules = modules
 
-    def func_set_script(self, source, row, column, buf_path, encoding):
-        self.script = jedi.Script(source, row, column, buf_path, encoding)
+    def func_set_script(self, *args, **kwargs):
+        self.script = jedi.Script(*args, **kwargs)
 
     def func_completions(self):
         return [_completion2dict(c) for c in self.script.completions()]
@@ -79,6 +79,7 @@ def _definition2dict(defi):
                   'is_keyword', 'desc_with_module', 'module_path',
                   'description', 'name', 'line', 'column')
     d['in_builtin_module'] = defi.in_builtin_module()
+    d['docstring'] = defi.docstring()
 
     return d
 

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -171,12 +171,13 @@ class JediRemote(object):
             self._process = None
 
     def _call(self, func, *args, **kwargs):
-        self.process.stdin.write(
-            json.dumps({'func': func, 'args': args, 'kwargs': kwargs}))
-        self.process.stdin.write('\n')
+        data = json.dumps({'func': func, 'args': args, 'kwargs': kwargs})
+        self.process.stdin.write(data.encode('utf-8'))
+        self.process.stdin.write(b'\n')
         self.process.stdin.flush()
 
-        ret = json.loads(self.process.stdout.readline(), object_hook=ObjectDict)
+        ret = json.loads(self.process.stdout.readline().decode('utf-8'),
+                         object_hook=ObjectDict)
 
         if ret['code'] == 'ok':
             return ret['return']

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -145,8 +145,9 @@ class JediRemote(object):
         self._process = None
 
     def __del__(self):
-        self._process.terminate()
-        self._process = None
+        if self._process is not None:
+            self._process.terminate()
+            self._process = None
 
     def __getattr__(self, name):
         return (lambda *args, **kwargs: self._call(name, *args, **kwargs))
@@ -165,8 +166,9 @@ class JediRemote(object):
         return self._process
 
     def reload(self):
-        self._process.terminate()
-        self._process = None
+        if self._process is not None:
+            self._process.terminate()
+            self._process = None
 
     def _call(self, func, *args, **kwargs):
         self.process.stdin.write(

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -154,7 +154,7 @@ class JediRemote(object):
 
     @property
     def process(self):
-        if self._process is None:
+        if not (self._process and self._process.poll() is None):
             cmd = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), self.remote_cmd)
             self._process = subprocess.Popen(


### PR DESCRIPTION
Currently, jedi.vim load jedi module using vim's builtin python interpreter, which restrict module explore path only from that python interpreter and virtualenvs created for that interpreter.

So, for example, if I use vim linking with python 2.7 and working on virtualenv created for python 3.4, jedi.vim doesn't list completion candidates installed on the venv.

To fix the problem, I propose splitting jedi loading process into external process and make jedi.vim communicate it through pipes.
Because any python interpreter can execute this external process, user can freely choose which python interpreter to use and get expected completion results.
It assume that "python interpreter user expected" is a command executed as a "python" for now.

I tested this code on linux and osx.
It may cause some problems on windows environment. (cause I have no windows installation, I couldn't test it.)
