### PR TITLE
split jedi into external process, v2

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -36,7 +36,7 @@ let s:default_settings = {
     \ 'force_py_version': "'auto'",
     \ 'smart_auto_mappings': 1,
     \ 'use_tag_stack': 1,
-    \ 'use_rpc': 0
+    \ 'use_external_python': "''"
 \ }
 
 for [s:key, s:val] in items(s:deprecations)

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -35,7 +35,8 @@ let s:default_settings = {
     \ 'completions_enabled': 1,
     \ 'force_py_version': "'auto'",
     \ 'smart_auto_mappings': 1,
-    \ 'use_tag_stack': 1
+    \ 'use_tag_stack': 1,
+    \ 'use_rpc': 0
 \ }
 
 for [s:key, s:val] in items(s:deprecations)

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -518,6 +518,16 @@ definition with arbitrary changes to the |jumplist|.
 Options: 0 or 1
 Default: 1 (enabled by default)
 
+------------------------------------------------------------------------------
+6.15. `g:jedi#use_rpc`                    *g:jedi#use_rpc*
+
+Fork external jedi process using system "python" command, instead of vim's
+internal |:python| interface.
+It allow you to get completion from python version other than vim link with.
+
+Options: 0 or 1
+Default: 0 (disabled by default)
+
 ==============================================================================
 7. Testing                              *jedi-vim-testing*
 

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -519,14 +519,14 @@ Options: 0 or 1
 Default: 1 (enabled by default)
 
 ------------------------------------------------------------------------------
-6.15. `g:jedi#use_rpc`                    *g:jedi#use_rpc*
+6.15. `g:jedi#use_external_python`              *g:jedi#use_external_python*
 
-Fork external jedi process using system "python" command, instead of vim's
-internal |:python| interface.
+Spawn external jedi process using system python command specified by this
+option, instead of vim's internal |:python| interface.
 It allow you to get completion from python version other than vim link with.
 
-Options: 0 or 1
-Default: 0 (disabled by default)
+Options: "python" or any other interpreter name you want to use
+Default: "" (disabled by default)
 
 ==============================================================================
 7. Testing                              *jedi-vim-testing*

--- a/jedi-remote-command.py
+++ b/jedi-remote-command.py
@@ -1,0 +1,102 @@
+'''jedi RPC server
+'''
+import json
+import os
+import sys
+import traceback
+
+# add path for jedi
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'jedi'))
+
+import jedi
+
+
+class JSONRPC(object):
+    def __init__(self, input=None, output=None):
+        if input is None:
+            input = sys.stdin
+
+        if output is None:
+            output = sys.stdout
+
+        self.input = input
+        self.output = output
+        self._objects = {}
+
+    def run(self):
+        for line in iter(self.input.readline, ''):
+            data = json.loads(line)
+
+            try:
+                func = getattr(self, 'func_' + data['func'])
+                ret = func(*data['args'], **data['kwargs'])
+            except Exception as e:
+                tb = traceback.format_exc()
+                result = {
+                    'code': 'ng',
+                    'exception': type(e).__name__,
+                    'args': e.args,
+                    'traceback': tb,
+                }
+            else:
+                result = {'code': 'ok', 'return': ret}
+
+            self._write_output(result)
+
+    def _write_output(self, data):
+        self.output.write(json.dumps(
+            data, default=self._remote_object_serializor))
+        self.output.write('\n')
+        self.output.flush()
+
+    def _remote_object_serializor(self, o):
+        # non JSON encode-able objects are managed on this process.
+        # it stored with unique ID and send this ID to client.
+        # client could access object's attributes through this ID.
+        ref = Ref(o)
+        self._objects[ref.id] = ref
+        # XXX: including builtin-typed attribute or selected, known to be used
+        #      attributes may improve overall performance, or may not.
+        return {'__type': 'RemoteObject', '__id': ref.id}
+
+    def func_get_from_jedi(self, name):
+        return getattr(jedi, name)
+
+    def func_free(self, id):
+        del self._objects[id]
+
+    def func_remote_object_getattr(self, id, *args, **kwargs):
+        obj = self._objects[id].target
+
+        return getattr(obj, *args, **kwargs)
+
+    def func_remote_object_setattr(self, id, *args, **kwargs):
+        obj = self._objects[id].target
+
+        return setattr(obj, *args, **kwargs)
+
+    def func_remote_object_call(self, id, *args, **kwargs):
+        obj = self._objects[id].target
+
+        return obj(*args, **kwargs)
+
+    def func_remote_object_repr(self, id, *args, **kwargs):
+        obj = self._objects[id].target
+
+        return repr(obj, *args, **kwargs)
+
+
+class Ref(object):
+    '''Reference
+
+    This class has reference for target object and publish unique ID.
+    '''
+    def __init__(self, target):
+        self.target = target
+        self.id = id(self)
+
+
+if __name__ == '__main__':
+    rpc = JSONRPC()
+    rpc.run()

--- a/jedi_remote.py
+++ b/jedi_remote.py
@@ -1,0 +1,127 @@
+from __future__ import print_function
+
+import json
+import os
+
+import jedi.api
+
+from subprocess import Popen, PIPE
+
+
+class JediRemote(object):
+    '''Jedi remote process communication client
+
+    This class provide jedi compatible API.
+    '''
+    python = 'python'
+    remote_command = 'jedi-remote-command.py'
+
+    def __init__(self, python=None):
+        if python is not None:
+            self.python = python
+
+        self._process = None
+
+    def __del__(self):
+        if self._process is not None:
+            # XXX: why does this raise exception?
+            #self._process.terminate()
+            self._process = None
+
+    @property
+    def process(self):
+        if self._process is None or self._process.poll() is not None:
+            cmd = os.path.join(
+                os.path.dirname(
+                    os.path.abspath(__file__)), self.remote_command)
+            self._process = Popen([self.python, cmd], stdin=PIPE, stdout=PIPE)
+
+        return self._process
+
+    def remote_object_getattr(self, id, *args, **kwargs):
+        return self._call_remote('remote_object_getattr', id, *args, **kwargs)
+
+    def remote_object_setattr(self, id, *args, **kwargs):
+        return self._call_remote('remote_object_setattr', id, *args, **kwargs)
+
+    def remote_object_call(self, id, *args, **kwargs):
+        return self._call_remote('remote_object_call', id, *args, **kwargs)
+
+    def remote_object_repr(self, id, *args, **kwargs):
+        return self._call_remote('remote_object_repr', id, *args, **kwargs)
+
+    def free(self, id):
+        return self._call_remote('free', id)
+
+    def __getattr__(self, name):
+        return self._call_remote('get_from_jedi', name)
+
+    def _call_remote(self, func, *args, **kwargs):
+        output = json.dumps({'func': func, 'args': args, 'kwargs': kwargs})
+
+        self.process.stdin.write(output.encode('utf-8'))
+        self.process.stdin.write(b'\n')
+        self.process.stdin.flush()
+
+        input = json.loads(self.process.stdout.readline().decode('utf-8'),
+                           object_hook=self.remote_object_hook)
+
+        if input.get('code') == 'ok':
+            return input['return']
+
+        elif input.get('code') == 'ng':
+            exception_name = input['exception']
+            e_args = input['args']
+
+            # try to find from jedi first
+            exception_class = getattr(jedi.api, exception_name, None)
+            if exception_class is None:
+                # ... and then, try to find from builtin
+                import __builtin__
+                exception_class = getattr(__builtin__, exception_name, None)
+
+            if exception_class is None:
+                exception_class = Exception
+                e_args = ('{}: {}'.format(exception_name, e_args), )
+
+            # print remote traceback to stdout, which will be in :messages
+            print(input.get('traceback'))
+            raise exception_class(*e_args)
+
+        else:
+            raise NotImplementedError(repr(input))
+
+    def remote_object_hook(self, obj):
+        if obj.get('__type') == 'RemoteObject':
+            return RemoteObject(self, obj['__id'])
+        else:
+            return obj
+
+    NotFoundError = jedi.api.NotFoundError
+
+
+class RemoteObject(object):
+    '''Remotely managed object
+
+    This class represents objects which managed on remote process.
+    It proxy accesses to remote process.
+    '''
+    def __init__(self, jedi_remote, id):
+        # to bypass this class's __setattr__, use super()
+        super(RemoteObject, self).__setattr__('_jedi_remote', jedi_remote)
+        super(RemoteObject, self).__setattr__('_id', id)
+
+    def __getattr__(self, name):
+        return self._jedi_remote.remote_object_getattr(self._id, name)
+
+    def __setattr__(self, name, value):
+        return self._jedi_remote.remote_object_setattr(self._id, name, value)
+
+    def __call__(self, *args, **kwargs):
+        return self._jedi_remote.remote_object_call(self._id, *args, **kwargs)
+
+    def __repr__(self):
+        return self._jedi_remote.remote_object_repr(self._id)
+
+    def __del__(self):
+        self._jedi_remote.free(self._id)

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -111,8 +111,9 @@ else:
         if version < (0, 7):
             echo_highlight('Please update your Jedi version, it is too old.')
 
-    import jedi_remote
-    jedi = jedi_remote.JediRemote()
+    if vim.vars.get('jedi#use_rpc'):
+        import jedi_remote
+        jedi = jedi_remote.JediRemote()
 
 
 def catch_and_print_exceptions(func):

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -111,6 +111,9 @@ else:
         if version < (0, 7):
             echo_highlight('Please update your Jedi version, it is too old.')
 
+    import jedi_remote
+    jedi = jedi_remote.JediRemote()
+
 
 def catch_and_print_exceptions(func):
     def wrapper(*args, **kwargs):

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -111,9 +111,10 @@ else:
         if version < (0, 7):
             echo_highlight('Please update your Jedi version, it is too old.')
 
-    if vim.vars.get('jedi#use_rpc'):
+    use_external_python = vim.vars.get('jedi#use_external_python')
+    if use_external_python:
         import jedi_remote
-        jedi = jedi_remote.JediRemote()
+        jedi = jedi_remote.JediRemote(use_external_python)
 
 
 def catch_and_print_exceptions(func):


### PR DESCRIPTION
It is second version of jedi RPC work. (v1, #507)

This time, RPC version of jedi object preserve original jedi compatible API.
I also added config option to toggle RPC code (disabled by default).
