### PR TITLE
Suppress warnings when python3_host_prog or python_host_prog is set

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -93,7 +93,7 @@ function! s:init_python()
 
         " Add a warning in case the auto-detected version is not available,
         " usually because of a missing neovim module in a VIRTUAL_ENV.
-        if has('nvim')
+        if has('nvim') && (!exists('g:python3_host_prog') && !exists('g:python_host_prog'))
             echohl WarningMsg
             echom "jedi-vim: the detected Python version (".s:def_py.")"
                         \ "is not functional."


### PR DESCRIPTION
- neovim uses Python neovim module where python3_host_prog or python_host_prog is pointing to
- e.g) `let g:python3_host_prog = expand('$HOME') . '/.virtualenvs/py3/bin/python3'`
- If one of those variable is set properly, skip sending warning message
- https://neovim.io/doc/user/nvim_python.html