### PR TITLE
call signatures: make them unique (as strings)

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -356,7 +356,11 @@ def show_call_signatures(signatures=()):
         return
 
     if signatures == ():
-        signatures = get_script().call_signatures()
+        sig_strs = []
+        for sig in get_script().call_signatures():
+            if str(sig) not in sig_strs:
+                sig_strs += [str(sig)]
+                signatures += (sig,)
     clear_call_signatures()
 
     if not signatures:


### PR DESCRIPTION
Jedi might return multiple call signatures, where the string
representation is the same.  This patch filters out duplicates.

Fixes https://github.com/davidhalter/jedi-vim/issues/531.
