### PR TITLE
jedi#smart_auto_mappings: use `\m` with `search()` for `magic`

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -503,7 +503,7 @@ endfunction
 
 function! jedi#smart_auto_mappings()
     " Auto put import statement after from module.name<space> and complete
-    if search('^\s*from\s\+[A-Za-z0-9._]\{1,50}\%#\s*$', 'bcn', line('.'))
+    if search('\m^\s*from\s\+[A-Za-z0-9._]\{1,50}\%#\s*$', 'bcn', line('.'))
         " Enter character and start completion.
         return "\<space>import \<C-x>\<C-o>\<C-r>=jedi#complete_opened(1)\<CR>"
     endif


### PR DESCRIPTION
With `nomagic` being set (not recommended, but might happen), the
pattern would not work.
This patch sets `\m` explicitly.