### PR TITLE
jedi#_vim_exceptions: return a string always

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -190,6 +190,9 @@ function! jedi#_vim_exceptions(str, is_eval)
     try
         if a:is_eval
             let l:result.result = eval(a:str)
+            if type(l:result.result) != type('')
+                let l:result.result = string(l:result.result)
+            endif
         else
             execute a:str
             let l:result.result = ''


### PR DESCRIPTION
Fixes https://github.com/davidhalter/jedi-vim/issues/553.