### PR TITLE
Improving from-import completion

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -49,5 +49,6 @@ Daniel Hahler (@blueyed)
 Dave Honneffer (@pearofducks)
 Bagrat Aznauryan (@n9code)
 Tomoyuki Kashiro (@kashiro)
+Frédéric Hamel (@FredericHamel)
 
 @something are github user names.


### PR DESCRIPTION
From import completions keep trace of all imported package.

For example:
```python
    from math import abs, 
```
The completion menu (not automatic) will display all other options (excluding abs) like cos, sin, ...
All other component still work.
