### PR TITLE
Bug fix: E492: Not an editor command: jedi_vim.clear_call_signatures()

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -354,7 +354,7 @@ function! jedi#do_popup_on_dot_in_highlight()
     for a in highlight_groups
         for b in ['pythonString', 'pythonComment', 'pythonNumber']
             if a == b
-                return 0 
+                return 0
             endif
         endfor
     endfor
@@ -399,7 +399,7 @@ function! jedi#clear_call_signatures()
     endif
 
     let s:show_call_signatures_last = [0, 0, '']
-    jedi_vim.clear_call_signatures()
+    PythonJedi jedi_vim.clear_call_signatures()
 endfunction
 
 


### PR DESCRIPTION
I got this error after I updated my local copy of jedi-vim to
'e8b88f0161ef2adabda97d4e083585a3becdcb53':
```
Error detected while processing function jedi#clear_call_signatures:
line    6:
E492: Not an editor command:     jedi_vim.clear_call_signatures()
```

The error below happened because 'PythonJedi' was missing before
jedi_vim.clear_call_signatures() in autoload/jedi.vim.

I put back 'PythonJedi' and it solved the issue.