### PR TITLE
Prevent redefinition of InsertLeave in buffers

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -49,5 +49,6 @@ Daniel Hahler (@blueyed)
 Dave Honneffer (@pearofducks)
 Bagrat Aznauryan (@n9code)
 Tomoyuki Kashiro (@kashiro)
+Tommy Allen (@tweekmonster)
 
 @something are github user names.

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -43,6 +43,9 @@ if g:jedi#auto_initialization
 
     if g:jedi#auto_close_doc
         " close preview if its still open after insert
-        autocmd InsertLeave <buffer> if pumvisible() == 0|pclose|endif
+        augroup jedi_preview
+            autocmd!
+            autocmd InsertLeave <buffer> if pumvisible() == 0|pclose|endif
+        augroup END
     endif
 endif


### PR DESCRIPTION
I was testing a plugin (setting/changing `filetype` a lot) and noticed the `autocmd` for closing preview windows was piling up.  As far as I can tell, there isn't a need to rerun the ftplugin after it's already setup.