### PR TITLE
Add <Plug>(jedi-goto) mapping to allow lazy loading for vim-plug

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -512,6 +512,8 @@ function! jedi#smart_auto_mappings()
 endfunction
 
 
+nnoremap <silent> <Plug>(jedi-goto) :<C-u>call jedi#goto()<CR>
+
 "PythonJedi jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout, speed=True, warnings=False, notices=False)
 "PythonJedi jedi_vim.jedi.set_debug_function(jedi_vim.print_to_stdout)
 


### PR DESCRIPTION
Hello,

For now jedi-vim can't be lazy loaded via plugin managers as vim-plug. But with <Plug> mapping it became possible. So I've add such mapping and now it's possible to load plugin if I try to use jedi#goto() function.

What do use think?
Am I do it in right way?
What I should to add? What functions remap to <Plug>?
