### PR TITLE
Do not set the '`' mark in goto

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -250,11 +250,6 @@ def goto(mode="goto", no_output=False):
         if not definitions:
             echo_highlight("Couldn't find any definitions for this.")
         elif len(definitions) == 1 and mode != "related_name":
-            # just add some mark to add the current position to the jumplist.
-            # this is ugly, because it overrides the mark for '`', so if anyone
-            # has a better idea, let me know.
-            vim_command('normal! m`')
-
             d = list(definitions)[0]
             if d.in_builtin_module():
                 if d.is_keyword:


### PR DESCRIPTION
This was meant as a hack to make the jumplist work (7520290), but it
works without it.  Maybe the underlying code to go to the definition has
been changed/improved.
Tested both in Vim (7.4.2143) and Neovim.