### PR TITLE
Hook into Neovim's :CheckHealth with jedi#debug_info

### DIFF
--- a/autoload/health/jedi.vim
+++ b/autoload/health/jedi.vim
@@ -1,0 +1,4 @@
+function! health#jedi#check() abort
+  call health#report_start('jedi')
+  silent call jedi#debug_info()
+endfunction

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -171,10 +171,10 @@ function! jedi#debug_info()
     PythonJedi print(' - site module: {0}'.format(__import__('site').__file__))
     PythonJedi print('Jedi path: {0}'.format(jedi_vim.jedi.__file__))
     PythonJedi print('Jedi version: {}'.format(jedi_vim.jedi.__version__))
-    echo 'jedi-vim git status: '
-    echon system('git -C '.s:script_path.' describe --tags --always --dirty')
-    echo 'jedi git status: '
-    echon system('git -C '.s:script_path.' submodule status')
+    echo 'jedi-vim git version: '
+    echon substitute(system('git -C '.s:script_path.' describe --tags --always --dirty'), '\v\n$', '', '')
+    echo 'jedi git submodule status: '
+    echon substitute(system('git -C '.s:script_path.' submodule status'), '\v\n$', '', '')
 endfunction
 
 


### PR DESCRIPTION
See https://github.com/neovim/neovim/blob/master/runtime/doc/pi_health.txt.

Example output for me:
```
…
health#jedi#check
================================================================================
## jedi
Using Python version: 3
 - sys.version: 3.5.2 (default, Jun 28 2016, 08:46:01), [GCC 6.1.1 20160602]
 - site module: /usr/lib/python3.5/site.py
Jedi path: /home/user/.dotfiles/vim/neobundles/jedi/jedi/jedi/__init__.py
Jedi version: 0.10.0
jedi-vim git version: 0.8.0-42-g7c7c376-dirty
jedi git submodule status: +be2a97cd36ce1b7d6f587ef122efc3433b1e8ae2 jedi (v0.9.0-533-gbe2a97c)
…
```
