### PR TITLE
prototype to call jedi completion server in subprocess

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,13 @@
+"""
+Run the completion server.
+"""
+
+from os import path
+import sys
+
+sys.path.append(path.join(path.dirname(__file__), 'jedi'))
+
+import completion
+
+if __name__ == '__main__':
+    completion.JediCompletion().watch()

--- a/attr/__init__.py
+++ b/attr/__init__.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import, division, print_function
+
+from ._funcs import (
+    asdict,
+    assoc,
+    has,
+)
+from ._make import (
+    Attribute,
+    Factory,
+    NOTHING,
+    attr,
+    attributes,
+    fields,
+    make_class,
+    validate,
+)
+from ._config import (
+    get_run_validators,
+    set_run_validators,
+)
+from . import exceptions
+from . import filters
+from . import validators
+
+
+__version__ = "16.1.0"
+
+__title__ = "attrs"
+__description__ = "Attributes Without Boilerplate"
+__uri__ = "https://attrs.readthedocs.io/"
+
+__author__ = "Hynek Schlawack"
+__email__ = "hs@ox.cx"
+
+__license__ = "MIT"
+__copyright__ = "Copyright (c) 2015 Hynek Schlawack"
+
+
+s = attrs = attributes
+ib = attrib = attr
+
+__all__ = [
+    "Attribute",
+    "Factory",
+    "NOTHING",
+    "asdict",
+    "assoc",
+    "attr",
+    "attrib",
+    "attributes",
+    "attrs",
+    "exceptions",
+    "fields",
+    "filters",
+    "get_run_validators",
+    "has",
+    "ib",
+    "make_class",
+    "s",
+    "set_run_validators",
+    "validate",
+    "validators",
+]

--- a/attr/_compat.py
+++ b/attr/_compat.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    import types
+
+    # We 'bundle' isclass instead of using inspect as importing inspect is
+    # fairly expensive (order of 10-15 ms for a modern machine in 2016)
+    def isclass(klass):
+        return isinstance(klass, (type, types.ClassType))
+
+    # TYPE is used in exceptions, repr(int) is different on Python 2 and 3.
+    TYPE = "type"
+
+    def exec_(code, locals_, globals_):
+        exec("exec code in locals_, globals_")
+
+    def iteritems(d):
+        return d.iteritems()
+
+    def iterkeys(d):
+        return d.iterkeys()
+else:
+    def isclass(klass):
+        return isinstance(klass, type)
+
+    TYPE = "class"
+
+    def exec_(code, locals_, globals_):
+        exec(code, locals_, globals_)
+
+    def iteritems(d):
+        return d.items()
+
+    def iterkeys(d):
+        return d.keys()

--- a/attr/_config.py
+++ b/attr/_config.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import, division, print_function
+
+
+__all__ = ["set_run_validators", "get_run_validators"]
+
+_run_validators = True
+
+
+def set_run_validators(run):
+    """
+    Set whether or not validators are run.  By default, they are run.
+    """
+    if not isinstance(run, bool):
+        raise TypeError("'run' must be bool.")
+    global _run_validators
+    _run_validators = run
+
+
+def get_run_validators():
+    """
+    Return whether or not validators are run.
+    """
+    return _run_validators

--- a/attr/_funcs.py
+++ b/attr/_funcs.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import, division, print_function
+
+import copy
+
+from ._compat import iteritems
+from ._make import Attribute, NOTHING, fields, _obj_setattr
+
+
+def asdict(inst, recurse=True, filter=None, dict_factory=dict,
+           retain_collection_types=False):
+    """
+    Return the ``attrs`` attribute values of *inst* as a dict.
+
+    Optionally recurse into other ``attrs``-decorated classes.
+
+    :param inst: Instance of an ``attrs``-decorated class.
+    :param bool recurse: Recurse into classes that are also
+        ``attrs``-decorated.
+    :param callable filter: A callable whose return code deteremines whether an
+        attribute or element is included (``True``) or dropped (``False``).  Is
+        called with the :class:`attr.Attribute` as the first argument and the
+        value as the second argument.
+    :param callable dict_factory: A callable to produce dictionaries from.  For
+        example, to produce ordered dictionaries instead of normal Python
+        dictionaries, pass in ``collections.OrderedDict``.
+    :param bool retain_collection_types: Do not convert to ``list`` when
+        encountering an attribute which is type ``tuple`` or ``set``.  Only
+        meaningful if ``recurse`` is ``True``.
+
+    :rtype: return type of *dict_factory*
+
+    ..  versionadded:: 16.0.0 *dict_factory*
+    ..  versionadded:: 16.1.0 *retain_collection_types*
+    """
+    attrs = fields(inst.__class__)
+    rv = dict_factory()
+    for a in attrs:
+        v = getattr(inst, a.name)
+        if filter is not None and not filter(a, v):
+            continue
+        if recurse is True:
+            if has(v.__class__):
+                rv[a.name] = asdict(v, recurse=True, filter=filter,
+                                    dict_factory=dict_factory)
+            elif isinstance(v, (tuple, list, set)):
+                cf = v.__class__ if retain_collection_types is True else list
+                rv[a.name] = cf([
+                    asdict(i, recurse=True, filter=filter,
+                           dict_factory=dict_factory)
+                    if has(i.__class__) else i
+                    for i in v
+                ])
+            elif isinstance(v, dict):
+                df = dict_factory
+                rv[a.name] = df((
+                    asdict(kk, dict_factory=df) if has(kk.__class__) else kk,
+                    asdict(vv, dict_factory=df) if has(vv.__class__) else vv)
+                    for kk, vv in iteritems(v))
+            else:
+                rv[a.name] = v
+        else:
+            rv[a.name] = v
+    return rv
+
+
+def has(cls):
+    """
+    Check whether *cls* is a class with ``attrs`` attributes.
+
+    :param type cls: Class to introspect.
+
+    :raise TypeError: If *cls* is not a class.
+
+    :rtype: :class:`bool`
+    """
+    return getattr(cls, "__attrs_attrs__", None) is not None
+
+
+def assoc(inst, **changes):
+    """
+    Copy *inst* and apply *changes*.
+
+    :param inst: Instance of a class with ``attrs`` attributes.
+
+    :param changes: Keyword changes in the new copy.
+
+    :return: A copy of inst with *changes* incorporated.
+    """
+    new = copy.copy(inst)
+    for k, v in iteritems(changes):
+        a = getattr(new.__class__, k, NOTHING)
+        if a is NOTHING or not isinstance(a, Attribute):
+            raise ValueError(
+                "{k} is not an attrs attribute on {cl}."
+                .format(k=k, cl=new.__class__)
+            )
+        _obj_setattr(new, k, v)
+    return new

--- a/attr/_make.py
+++ b/attr/_make.py
@@ -1,0 +1,698 @@
+from __future__ import absolute_import, division, print_function
+
+import hashlib
+import linecache
+
+from . import _config
+from ._compat import exec_, iteritems, isclass, iterkeys
+from .exceptions import FrozenInstanceError
+
+# This is used at least twice, so cache it here.
+_obj_setattr = object.__setattr__
+
+
+class _Nothing(object):
+    """
+    Sentinel class to indicate the lack of a value when ``None`` is ambiguous.
+
+    All instances of `_Nothing` are equal.
+    """
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, _):
+        return self
+
+    def __eq__(self, other):
+        return other.__class__ == _Nothing
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):
+        return "NOTHING"
+
+    def __hash__(self):
+        return 0xdeadbeef
+
+
+NOTHING = _Nothing()
+"""
+Sentinel to indicate the lack of a value when ``None`` is ambiguous.
+"""
+
+
+def attr(default=NOTHING, validator=None,
+         repr=True, cmp=True, hash=True, init=True,
+         convert=None):
+    """
+    Create a new attribute on a class.
+
+    ..  warning::
+
+        Does *not* do anything unless the class is also decorated with
+        :func:`attr.s`!
+
+    :param default: A value that is used if an ``attrs``-generated ``__init__``
+        is used and no value is passed while instantiating or the attribute is
+        excluded using ``init=False``.
+
+        If the value is an instance of :class:`Factory`, its callable will be
+        used to construct a new value (useful for mutable datatypes like lists
+        or dicts).
+
+        If a default is not set (or set manually to ``attr.NOTHING``), a value
+        *must* be supplied when instantiating; otherwise a :exc:`TypeError`
+        will be raised.
+
+    :type default: Any value.
+
+    :param callable validator: :func:`callable` that is called by
+        ``attrs``-generated ``__init__`` methods after the instance has been
+        initialized.  They receive the initialized instance, the
+        :class:`Attribute`, and the passed value.
+
+        The return value is *not* inspected so the validator has to throw an
+        exception itself.
+
+        They can be globally disabled and re-enabled using
+        :func:`get_run_validators`.
+
+    :param bool repr: Include this attribute in the generated ``__repr__``
+        method.
+    :param bool cmp: Include this attribute in the generated comparison methods
+        (``__eq__`` et al).
+    :param bool hash: Include this attribute in the generated ``__hash__``
+        method.
+    :param bool init: Include this attribute in the generated ``__init__``
+        method.  It is possible to set this to ``False`` and set a default
+        value.  In that case this attributed is unconditionally initialized
+        with the specified default value or factory.
+    :param callable convert: :func:`callable` that is called by
+        ``attrs``-generated ``__init__`` methods to convert attribute's value
+        to the desired format.  It is given the passed-in value, and the
+        returned value will be used as the new value of the attribute.  The
+        value is converted before being passed to the validator, if any.
+    """
+    return _CountingAttr(
+        default=default,
+        validator=validator,
+        repr=repr,
+        cmp=cmp,
+        hash=hash,
+        init=init,
+        convert=convert,
+    )
+
+
+def _transform_attrs(cls, these):
+    """
+    Transforms all `_CountingAttr`s on a class into `Attribute`s and saves the
+    list as a tuple in `__attrs_attrs__`.
+
+    If *these* is passed, use that and don't look for them on the class.
+    """
+    super_cls = []
+    for c in reversed(cls.__mro__[1:-1]):
+        sub_attrs = getattr(c, "__attrs_attrs__", None)
+        if sub_attrs is not None:
+            super_cls.extend(a for a in sub_attrs if a not in super_cls)
+    if these is None:
+        ca_list = [(name, attr)
+                   for name, attr
+                   in cls.__dict__.items()
+                   if isinstance(attr, _CountingAttr)]
+    else:
+        ca_list = [(name, ca)
+                   for name, ca
+                   in iteritems(these)]
+
+    cls.__attrs_attrs__ = tuple(super_cls + [
+        Attribute.from_counting_attr(name=attr_name, ca=ca)
+        for attr_name, ca
+        in sorted(ca_list, key=lambda e: e[1].counter)
+    ])
+
+    had_default = False
+    for a in cls.__attrs_attrs__:
+        if these is None and a not in super_cls:
+            setattr(cls, a.name, a)
+        if had_default is True and a.default is NOTHING and a.init is True:
+            raise ValueError(
+                "No mandatory attributes allowed after an attribute with a "
+                "default value or factory.  Attribute in question: {a!r}"
+                .format(a=a)
+            )
+        elif had_default is False and \
+                a.default is not NOTHING and \
+                a.init is not False:
+            had_default = True
+
+
+def _frozen_setattrs(self, name, value):
+    """
+    Attached to frozen classes as __setattr__.
+    """
+    raise FrozenInstanceError()
+
+
+def attributes(maybe_cls=None, these=None, repr_ns=None,
+               repr=True, cmp=True, hash=True, init=True,
+               slots=False, frozen=False):
+    """
+    A class decorator that adds `dunder
+    <https://wiki.python.org/moin/DunderAlias>`_\ -methods according to the
+    specified attributes using :func:`attr.ib` or the *these* argument.
+
+    :param these: A dictionary of name to :func:`attr.ib` mappings.  This is
+        useful to avoid the definition of your attributes within the class body
+        because you can't (e.g. if you want to add ``__repr__`` methods to
+        Django models) or don't want to (e.g. if you want to use
+        :class:`properties <property>`).
+
+        If *these* is not `None`, the class body is *ignored*.
+
+    :type these: :class:`dict` of :class:`str` to :func:`attr.ib`
+
+    :param str repr_ns: When using nested classes, there's no way in Python 2
+        to automatically detect that.  Therefore it's possible to set the
+        namespace explicitly for a more meaningful ``repr`` output.
+    :param bool repr: Create a ``__repr__`` method with a human readable
+        represantation of ``attrs`` attributes..
+    :param bool cmp: Create ``__eq__``, ``__ne__``, ``__lt__``, ``__le__``,
+        ``__gt__``, and ``__ge__`` methods that compare the class as if it were
+        a tuple of its ``attrs`` attributes.  But the attributes are *only*
+        compared, if the type of both classes is *identical*!
+    :param bool hash: Create a ``__hash__`` method that returns the
+        :func:`hash` of a tuple of all ``attrs`` attribute values.
+    :param bool init: Create a ``__init__`` method that initialiazes the
+        ``attrs`` attributes.  Leading underscores are stripped for the
+        argument name.
+    :param bool slots: Create a slots_-style class that's more
+        memory-efficient.  See :ref:`slots` for further ramifications.
+    :param bool frozen: Make instances immutable after initialization.  If
+        someone attempts to modify a frozen instance,
+        :exc:`attr.exceptions.FrozenInstanceError` is raised.
+
+        Please note:
+
+            1. This is achieved by installing a custom ``__setattr__`` method
+               on your class so you can't implement an own one.
+
+            2. True immutability is impossible in Python.
+
+            3. This *does* have a minor a runtime performance :ref:`impact
+               <how-frozen>` when initializing new instances.  In other words:
+               ``__init__`` is slightly slower with ``frozen=True``.
+
+        ..  _slots: https://docs.python.org/3.5/reference/datamodel.html#slots
+
+    ..  versionadded:: 16.0.0 *slots*
+    ..  versionadded:: 16.1.0 *frozen*
+    """
+    def wrap(cls):
+        if getattr(cls, "__class__", None) is None:
+            raise TypeError("attrs only works with new-style classes.")
+        if slots:
+            # Only need this later if we're using slots.
+            if these is None:
+                ca_list = [name
+                           for name, attr
+                           in cls.__dict__.items()
+                           if isinstance(attr, _CountingAttr)]
+            else:
+                ca_list = list(iterkeys(these))
+        _transform_attrs(cls, these)
+        if repr is True:
+            cls = _add_repr(cls, ns=repr_ns)
+        if cmp is True:
+            cls = _add_cmp(cls)
+        if hash is True:
+            cls = _add_hash(cls)
+        if init is True:
+            cls = _add_init(cls, frozen)
+        if frozen is True:
+            cls.__setattr__ = _frozen_setattrs
+        if slots is True:
+            cls_dict = dict(cls.__dict__)
+            cls_dict["__slots__"] = tuple(ca_list)
+            for ca_name in ca_list:
+                # It might not actually be in there, e.g. if using 'these'.
+                cls_dict.pop(ca_name, None)
+            cls_dict.pop('__dict__', None)
+
+            if repr_ns is None:
+                cls_name = getattr(cls, "__qualname__", cls.__name__)
+            else:
+                cls_name = cls.__name__
+
+            cls = type(cls_name, cls.__bases__, cls_dict)
+
+        return cls
+
+    # attrs_or class type depends on the usage of the decorator.  It's a class
+    # if it's used as `@attributes` but ``None`` if used # as `@attributes()`.
+    if maybe_cls is None:
+        return wrap
+    else:
+        return wrap(maybe_cls)
+
+
+def _attrs_to_tuple(obj, attrs):
+    """
+    Create a tuple of all values of *obj*'s *attrs*.
+    """
+    return tuple(getattr(obj, a.name) for a in attrs)
+
+
+def _add_hash(cls, attrs=None):
+    """
+    Add a hash method to *cls*.
+    """
+    if attrs is None:
+        attrs = [a for a in cls.__attrs_attrs__ if a.hash]
+
+    def hash_(self):
+        """
+        Automatically created by attrs.
+        """
+        return hash(_attrs_to_tuple(self, attrs))
+
+    cls.__hash__ = hash_
+    return cls
+
+
+def _add_cmp(cls, attrs=None):
+    """
+    Add comparison methods to *cls*.
+    """
+    if attrs is None:
+        attrs = [a for a in cls.__attrs_attrs__ if a.cmp]
+
+    def attrs_to_tuple(obj):
+        """
+        Save us some typing.
+        """
+        return _attrs_to_tuple(obj, attrs)
+
+    def eq(self, other):
+        """
+        Automatically created by attrs.
+        """
+        if other.__class__ is self.__class__:
+            return attrs_to_tuple(self) == attrs_to_tuple(other)
+        else:
+            return NotImplemented
+
+    def ne(self, other):
+        """
+        Automatically created by attrs.
+        """
+        result = eq(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        else:
+            return not result
+
+    def lt(self, other):
+        """
+        Automatically created by attrs.
+        """
+        if isinstance(other, self.__class__):
+            return attrs_to_tuple(self) < attrs_to_tuple(other)
+        else:
+            return NotImplemented
+
+    def le(self, other):
+        """
+        Automatically created by attrs.
+        """
+        if isinstance(other, self.__class__):
+            return attrs_to_tuple(self) <= attrs_to_tuple(other)
+        else:
+            return NotImplemented
+
+    def gt(self, other):
+        """
+        Automatically created by attrs.
+        """
+        if isinstance(other, self.__class__):
+            return attrs_to_tuple(self) > attrs_to_tuple(other)
+        else:
+            return NotImplemented
+
+    def ge(self, other):
+        """
+        Automatically created by attrs.
+        """
+        if isinstance(other, self.__class__):
+            return attrs_to_tuple(self) >= attrs_to_tuple(other)
+        else:
+            return NotImplemented
+
+    cls.__eq__ = eq
+    cls.__ne__ = ne
+    cls.__lt__ = lt
+    cls.__le__ = le
+    cls.__gt__ = gt
+    cls.__ge__ = ge
+
+    return cls
+
+
+def _add_repr(cls, ns=None, attrs=None):
+    """
+    Add a repr method to *cls*.
+    """
+    if attrs is None:
+        attrs = [a for a in cls.__attrs_attrs__ if a.repr]
+
+    def repr_(self):
+        """
+        Automatically created by attrs.
+        """
+        real_cls = self.__class__
+        if ns is None:
+            qualname = getattr(real_cls, "__qualname__", None)
+            if qualname is not None:
+                class_name = qualname.rsplit(">.", 1)[-1]
+            else:
+                class_name = real_cls.__name__
+        else:
+            class_name = ns + "." + real_cls.__name__
+
+        return "{0}({1})".format(
+            class_name,
+            ", ".join(a.name + "=" + repr(getattr(self, a.name))
+                      for a in attrs)
+        )
+    cls.__repr__ = repr_
+    return cls
+
+
+def _add_init(cls, frozen):
+    """
+    Add a __init__ method to *cls*.  If *frozen* is True, make it immutable.
+    """
+    attrs = [a for a in cls.__attrs_attrs__
+             if a.init or a.default is not NOTHING]
+
+    # We cache the generated init methods for the same kinds of attributes.
+    sha1 = hashlib.sha1()
+    sha1.update(repr(attrs).encode("utf-8"))
+    unique_filename = "<attrs generated init {0}>".format(
+        sha1.hexdigest()
+    )
+
+    script, globs = _attrs_to_script(attrs, frozen)
+    locs = {}
+    bytecode = compile(script, unique_filename, "exec")
+    attr_dict = dict((a.name, a) for a in attrs)
+    globs.update({
+        "NOTHING": NOTHING,
+        "attr_dict": attr_dict,
+        "validate": validate,
+        "_convert": _convert
+    })
+    if frozen is True:
+        # Save the lookup overhead in __init__ if we need to circumvent
+        # immutability.
+        globs["_cached_setattr"] = _obj_setattr
+    exec_(bytecode, globs, locs)
+    init = locs["__init__"]
+
+    # In order of debuggers like PDB being able to step through the code,
+    # we add a fake linecache entry.
+    linecache.cache[unique_filename] = (
+        len(script),
+        None,
+        script.splitlines(True),
+        unique_filename
+    )
+    cls.__init__ = init
+    return cls
+
+
+def fields(cls):
+    """
+    Returns the tuple of ``attrs`` attributes for a class.
+
+    :param type cls: Class to introspect.
+
+    :raise TypeError: If *cls* is not a class.
+    :raise ValueError: If *cls* is not an ``attrs`` class.
+
+    :rtype: tuple of :class:`attr.Attribute`
+    """
+    if not isclass(cls):
+        raise TypeError("Passed object must be a class.")
+    attrs = getattr(cls, "__attrs_attrs__", None)
+    if attrs is None:
+        raise ValueError("{cls!r} is not an attrs-decorated class.".format(
+            cls=cls
+        ))
+    return attrs
+
+
+def validate(inst):
+    """
+    Validate all attributes on *inst* that have a validator.
+
+    Leaves all exceptions through.
+
+    :param inst: Instance of a class with ``attrs`` attributes.
+    """
+    if _config._run_validators is False:
+        return
+
+    for a in fields(inst.__class__):
+        if a.validator is not None:
+            a.validator(inst, a, getattr(inst, a.name))
+
+
+def _convert(inst):
+    """
+    Convert all attributes on *inst* that have a converter.
+
+    Leaves all exceptions through.
+
+    :param inst: Instance of a class with ``attrs`` attributes.
+    """
+    for a in inst.__class__.__attrs_attrs__:
+        if a.convert is not None:
+            setattr(inst, a.name, a.convert(getattr(inst, a.name)))
+
+
+def _attrs_to_script(attrs, frozen):
+    """
+    Return a script of an initializer for *attrs* and a dict of globals.
+
+    The globals are expected by the generated script.
+
+     If *frozen* is True, we cannot set the attributes directly so we use
+    a cached ``object.__setattr__``.
+    """
+    lines = []
+    if frozen is True:
+        lines.append(
+            # Circumvent the __setattr__ descriptor to save one lookup per
+            # assignment.
+            "_setattr = _cached_setattr.__get__(self, self.__class__)"
+        )
+
+        def fmt_setter(attr_name, value):
+            return "_setattr('%(attr_name)s', %(value)s)" % {
+                "attr_name": attr_name,
+                "value": value,
+            }
+    else:
+        def fmt_setter(attr_name, value):
+            return "self.%(attr_name)s = %(value)s" % {
+                "attr_name": attr_name,
+                "value": value,
+            }
+
+    args = []
+    has_convert = False
+    attrs_to_validate = []
+
+    # This is a dictionary of names to validator callables. Injecting
+    # this into __init__ globals lets us avoid lookups.
+    validators_for_globals = {}
+
+    for a in attrs:
+        if a.validator is not None:
+            attrs_to_validate.append(a)
+        if a.convert is not None:
+            has_convert = True
+        attr_name = a.name
+        arg_name = a.name.lstrip("_")
+        if a.init is False:
+            if isinstance(a.default, Factory):
+                lines.append(fmt_setter(
+                    attr_name,
+                    "attr_dict['{attr_name}'].default.factory()"
+                    .format(attr_name=attr_name)
+                ))
+            else:
+                lines.append(fmt_setter(
+                    attr_name,
+                    "attr_dict['{attr_name}'].default"
+                    .format(attr_name=attr_name)
+                ))
+        elif a.default is not NOTHING and not isinstance(a.default, Factory):
+            args.append(
+                "{arg_name}=attr_dict['{attr_name}'].default".format(
+                    arg_name=arg_name,
+                    attr_name=attr_name,
+                )
+            )
+            lines.append(fmt_setter(attr_name, arg_name))
+        elif a.default is not NOTHING and isinstance(a.default, Factory):
+            args.append("{arg_name}=NOTHING".format(arg_name=arg_name))
+            lines.append("if {arg_name} is not NOTHING:"
+                         .format(arg_name=arg_name))
+            lines.append("    " + fmt_setter(attr_name, arg_name))
+            lines.append("else:")
+            lines.append("    " + fmt_setter(
+                attr_name,
+                "attr_dict['{attr_name}'].default.factory()"
+                .format(attr_name=attr_name)
+            ))
+        else:
+            args.append(arg_name)
+            lines.append(fmt_setter(attr_name, arg_name))
+
+    if has_convert:
+        lines.append("_convert(self)")
+    if attrs_to_validate:  # we can skip this if there are no validators.
+        validators_for_globals["_config"] = _config
+        lines.append("if _config._run_validators is False:")
+        lines.append("    return")
+    for a in attrs_to_validate:
+        val_name = "__attr_validator_{}".format(a.name)
+        attr_name = "__attr_{}".format(a.name)
+        lines.append("{}(self, {}, self.{})".format(val_name, attr_name,
+                                                    a.name))
+        validators_for_globals[val_name] = a.validator
+        validators_for_globals[attr_name] = a
+
+    return """\
+def __init__(self, {args}):
+    {lines}
+""".format(
+        args=", ".join(args),
+        lines="\n    ".join(lines) if lines else "pass",
+    ), validators_for_globals
+
+
+class Attribute(object):
+    """
+    *Read-only* representation of an attribute.
+
+    :attribute name: The name of the attribute.
+
+    Plus *all* arguments of :func:`attr.ib`.
+    """
+    __slots__ = ('name', 'default', 'validator', 'repr', 'cmp', 'hash', 'init',
+                 'convert')
+
+    _optional = {"convert": None}
+
+    def __init__(self, name, default, validator, repr, cmp, hash, init,
+                 convert=None):
+        # Cache this descriptor here to speed things up later.
+        __bound_setattr = _obj_setattr.__get__(self, Attribute)
+
+        __bound_setattr('name', name)
+        __bound_setattr('default', default)
+        __bound_setattr('validator', validator)
+        __bound_setattr('repr', repr)
+        __bound_setattr('cmp', cmp)
+        __bound_setattr('hash', hash)
+        __bound_setattr('init', init)
+        __bound_setattr('convert', convert)
+
+    def __setattr__(self, name, value):
+        raise FrozenInstanceError()
+
+    @classmethod
+    def from_counting_attr(cls, name, ca):
+        return cls(name=name,
+                   **dict((k, getattr(ca, k))
+                          for k
+                          in Attribute.__slots__
+                          if k != "name"))
+
+
+_a = [Attribute(name=name, default=NOTHING, validator=None,
+                repr=True, cmp=True, hash=True, init=True)
+      for name in Attribute.__slots__]
+Attribute = _add_hash(
+    _add_cmp(_add_repr(Attribute, attrs=_a), attrs=_a), attrs=_a
+)
+
+
+class _CountingAttr(object):
+    """
+    Intermediate representation of attributes that uses a counter to preserve
+    the order in which the attributes have been defined.
+    """
+    __attrs_attrs__ = [
+        Attribute(name=name, default=NOTHING, validator=None,
+                  repr=True, cmp=True, hash=True, init=True)
+        for name
+        in ("counter", "default", "repr", "cmp", "hash", "init",)
+    ]
+    counter = 0
+
+    def __init__(self, default, validator, repr, cmp, hash, init, convert):
+        _CountingAttr.counter += 1
+        self.counter = _CountingAttr.counter
+        self.default = default
+        self.validator = validator
+        self.repr = repr
+        self.cmp = cmp
+        self.hash = hash
+        self.init = init
+        self.convert = convert
+
+
+_CountingAttr = _add_cmp(_add_repr(_CountingAttr))
+
+
+@attributes(slots=True)
+class Factory(object):
+    """
+    Stores a factory callable.
+
+    If passed as the default value to :func:`attr.ib`, the factory is used to
+    generate a new value.
+    """
+    factory = attr()
+
+
+def make_class(name, attrs, **attributes_arguments):
+    """
+    A quick way to create a new class called *name* with *attrs*.
+
+    :param name: The name for the new class.
+    :type name: str
+
+    :param attrs: A list of names or a dictionary of mappings of names to
+        attributes.
+    :type attrs: :class:`list` or :class:`dict`
+
+    :param attributes_arguments: Passed unmodified to :func:`attr.s`.
+
+    :return: A new class with *attrs*.
+    :rtype: type
+    """
+    if isinstance(attrs, dict):
+        cls_dict = attrs
+    elif isinstance(attrs, (list, tuple)):
+        cls_dict = dict((a, attr()) for a in attrs)
+    else:
+        raise TypeError("attrs argument must be a dict or a list.")
+
+    return attributes(**attributes_arguments)(type(name, (object,), cls_dict))

--- a/attr/exceptions.py
+++ b/attr/exceptions.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, division, print_function
+
+
+class FrozenInstanceError(AttributeError):
+    """
+    A frozen/immutable instance has been attempted to be modified.
+
+    It mirrors the behavior of ``namedtuples`` by using the same error message
+    and subclassing :exc:`AttributeError``.
+    """
+    msg = "can't set attribute"
+    args = [msg]

--- a/attr/filters.py
+++ b/attr/filters.py
@@ -1,0 +1,52 @@
+"""
+Commonly useful filters for :func:`attr.asdict`.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from ._compat import isclass
+from ._make import Attribute
+
+
+def _split_what(what):
+    """
+    Returns a tuple of `frozenset`s of classes and attributes.
+    """
+    return (
+        frozenset(cls for cls in what if isclass(cls)),
+        frozenset(cls for cls in what if isinstance(cls, Attribute)),
+    )
+
+
+def include(*what):
+    """
+    Whitelist *what*.
+
+    :param what: What to whitelist.
+    :type what: :class:`list` of :class:`type` or :class:`attr.Attribute` s.
+
+    :rtype: :class:`callable`
+    """
+    cls, attrs = _split_what(what)
+
+    def include_(attribute, value):
+        return value.__class__ in cls or attribute in attrs
+
+    return include_
+
+
+def exclude(*what):
+    """
+    Blacklist *what*.
+
+    :param what: What to blacklist.
+    :type what: :class:`list` of classes or :class:`attr.Attribute` s.
+
+    :rtype: :class:`callable`
+    """
+    cls, attrs = _split_what(what)
+
+    def exclude_(attribute, value):
+        return value.__class__ not in cls and attribute not in attrs
+
+    return exclude_

--- a/attr/validators.py
+++ b/attr/validators.py
@@ -1,0 +1,114 @@
+"""
+Commonly useful validators.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from ._make import attr, attributes
+
+
+@attributes(repr=False, slots=True)
+class _InstanceOfValidator(object):
+    type = attr()
+
+    def __call__(self, inst, attr, value):
+        """
+        We use a callable class to be able to change the ``__repr__``.
+        """
+        if not isinstance(value, self.type):
+            raise TypeError(
+                "'{name}' must be {type!r} (got {value!r} that is a "
+                "{actual!r})."
+                .format(name=attr.name, type=self.type,
+                        actual=value.__class__, value=value),
+                attr, self.type, value,
+            )
+
+    def __repr__(self):
+        return (
+            "<instance_of validator for type {type!r}>"
+            .format(type=self.type)
+        )
+
+
+def instance_of(type):
+    """
+    A validator that raises a :exc:`TypeError` if the initializer is called
+    with a wrong type for this particular attribute (checks are perfomed using
+    :func:`isinstance` therefore it's also valid to pass a tuple of types).
+
+    :param type: The type to check for.
+    :type type: type or tuple of types
+
+    The :exc:`TypeError` is raised with a human readable error message, the
+    attribute (of type :class:`attr.Attribute`), the expected type, and the
+    value it got.
+    """
+    return _InstanceOfValidator(type)
+
+
+@attributes(repr=False, slots=True)
+class _ProvidesValidator(object):
+    interface = attr()
+
+    def __call__(self, inst, attr, value):
+        """
+        We use a callable class to be able to change the ``__repr__``.
+        """
+        if not self.interface.providedBy(value):
+            raise TypeError(
+                "'{name}' must provide {interface!r} which {value!r} "
+                "doesn't."
+                .format(name=attr.name, interface=self.interface, value=value),
+                attr, self.interface, value,
+            )
+
+    def __repr__(self):
+        return (
+            "<provides validator for interface {interface!r}>"
+            .format(interface=self.interface)
+        )
+
+
+def provides(interface):
+    """
+    A validator that raises a :exc:`TypeError` if the initializer is called
+    with an object that does not provide the requested *interface* (checks are
+    performed using ``interface.providedBy(value)`` (see `zope.interface
+    <http://docs.zope.org/zope.interface/>`_).
+
+    :param interface: The interface to check for.
+    :type interface: zope.interface.Interface
+
+    The :exc:`TypeError` is raised with a human readable error message, the
+    attribute (of type :class:`attr.Attribute`), the expected interface, and
+    the value it got.
+    """
+    return _ProvidesValidator(interface)
+
+
+@attributes(repr=False, slots=True)
+class _OptionalValidator(object):
+    validator = attr()
+
+    def __call__(self, inst, attr, value):
+        if value is None:
+            return
+        return self.validator(inst, attr, value)
+
+    def __repr__(self):
+        return (
+            "<optional validator for {type} or None>"
+            .format(type=repr(self.validator))
+        )
+
+
+def optional(validator):
+    """
+    A validator that makes an attribute optional.  An optional attribute is one
+    which can be set to ``None`` in addition to satisfying the requirements of
+    the sub-validator.
+
+    :param validator: A validator that is used for non-``None`` values.
+    """
+    return _OptionalValidator(validator)

--- a/completion.py
+++ b/completion.py
@@ -1,0 +1,404 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 DonJayamanne
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import io
+import re
+import sys
+import json
+import traceback
+sys.path.append(os.path.dirname(__file__))
+import jedi
+# remove jedi from path after we import it so it will not be completed
+sys.path.pop(0)
+
+WORD_RE = re.compile(r'\w')
+
+
+class JediCompletion(object):
+    basic_types = {
+        'module': 'import',
+        'instance': 'variable',
+        'statement': 'value',
+        'param': 'variable',
+    }
+
+    def __init__(self):
+        self.default_sys_path = sys.path
+        self._input = io.open(sys.stdin.fileno(), encoding='utf-8')
+
+    def _get_definition_type(self, definition):
+        is_built_in = definition.in_builtin_module
+        if definition.type not in ['import', 'keyword'] and is_built_in():
+            return 'builtin'
+        if definition.type in ['statement'] and definition.name.isupper():
+            return 'constant'
+        return self.basic_types.get(definition.type, definition.type)
+
+    def _additional_info(self, completion):
+        """Provide additional information about the completion object."""
+        if completion._definition is None:
+            return ''
+        if completion.type == 'statement':
+            nodes_to_display = ['InstanceElement', 'String', 'Node', 'Lambda',
+                                'Number']
+            return ''.join(c.get_code() for c in
+                           completion._definition.children if type(c).__name__
+                           in nodes_to_display).replace('\n', '')
+        return ''
+
+    @classmethod
+    def _get_top_level_module(cls, path):
+        """Recursively walk through directories looking for top level module.
+
+        Jedi will use current filepath to look for another modules at same
+        path, but it will not be able to see modules **above**, so our goal
+        is to find the higher python module available from filepath.
+        """
+        _path, _ = os.path.split(path)
+        if os.path.isfile(os.path.join(_path, '__init__.py')):
+            return cls._get_top_level_module(_path)
+        return path
+
+    def _generate_signature(self, completion):
+        """Generate signature with function arguments.
+        """
+        if not hasattr(completion, 'params'):
+            return ''
+        return '%s(%s)' % (
+            completion.name,
+            ', '.join(param.description for param in completion.params))
+
+    def _get_call_signatures(self, script):
+        """Extract call signatures from jedi.api.Script object in failsafe way.
+
+        Returns:
+            Tuple with original signature object, name and value.
+        """
+        _signatures = []
+        try:
+            call_signatures = script.call_signatures()
+        except KeyError:
+            call_signatures = []
+        for signature in call_signatures:
+            for pos, param in enumerate(signature.params):
+                if not param.name:
+                    continue
+                if param.name == 'self' and pos == 0:
+                    continue
+                if WORD_RE.match(param.name) is None:
+                    continue
+                try:
+                    name, value = param.description.split('=')
+                except ValueError:
+                    name = param.description
+                    value = None
+                if name.startswith('*'):
+                    continue
+                _signatures.append((signature, name, value))
+        return _signatures
+
+    def _get_call_signatures_with_args(self, script):
+        """Extract call signatures from jedi.api.Script object in failsafe way.
+
+        Returns:
+            Array with dictionary
+        """
+        _signatures = []
+        try:
+            call_signatures = script.call_signatures()
+        except KeyError:
+            call_signatures = []
+        for signature in call_signatures:
+            sig = {"name": "", "description": "", "docstring": "",
+                   "paramindex": 0, "params": [], "bracketstart": []}
+            sig["description"] = signature.description
+            sig["docstring"] = signature.docstring()
+            sig["name"] = signature.name
+            sig["paramindex"] = signature.index
+            sig["bracketstart"].append(signature.index)
+
+            _signatures.append(sig)
+            for pos, param in enumerate(signature.params):
+                if not param.name:
+                    continue
+                if param.name == 'self' and pos == 0:
+                    continue
+                if WORD_RE.match(param.name) is None:
+                    continue
+                try:
+                    name, value = param.description.split('=')
+                except ValueError:
+                    name = param.description
+                    value = None
+                #if name.startswith('*'):
+                #    continue
+                #_signatures.append((signature, name, value))
+                sig["params"].append({"name": name, "value":value, "docstring":param.docstring(), "description":param.description})
+        return _signatures
+
+    def _serialize_completions(self, script, identifier=None, prefix=''):
+        """Serialize response to be read from VSCode.
+
+        Args:
+            script: Instance of jedi.api.Script object.
+            identifier: Unique completion identifier to pass back to VSCode.
+            prefix: String with prefix to filter function arguments.
+                Used only when fuzzy matcher turned off.
+
+        Returns:
+            Serialized string to send to VSCode.
+        """
+        _completions = []
+
+        for signature, name, value in []: # self._get_call_signatures(script):
+            if not self.fuzzy_matcher and not name.lower().startswith(
+              prefix.lower()):
+                continue
+            _completion = {
+                'type': 'property',
+                'rightLabel': self._additional_info(signature)
+            }
+            # we pass 'text' here only for fuzzy matcher
+            if value:
+                _completion['snippet'] = '%s=${1:%s}$0' % (name, value)
+                _completion['text'] = '%s=%s' % (name, value)
+            else:
+                _completion['snippet'] = '%s=$1$0' % name
+                _completion['text'] = name
+                _completion['displayText'] = name
+            if self.show_doc_strings:
+                _completion['description'] = signature.docstring()
+            else:
+                _completion['description'] = self._generate_signature(
+                    signature)
+            _completions.append(_completion)
+
+        try:
+            completions = script.completions()
+        except KeyError:
+            completions = []
+        for completion in completions:
+            if self.show_doc_strings:
+                description = completion.docstring()
+            else:
+                description = self._generate_signature(completion)
+            _completion = {
+                'text': completion.name,
+                'type': self._get_definition_type(completion),
+                'description': description,
+                'rightLabel': self._additional_info(completion)
+            }
+            # for jedi-vim
+            _completion = {
+                'name': completion.name,
+                'complete': completion.complete,
+                'name_with_symbols': completion.name_with_symbols,
+                'description': completion.description,
+                'docstring_': completion.docstring(),
+            }
+            # if any([c['text'].split('=')[0] == _completion['text']
+            #         for c in _completions]):
+            #   # ignore function arguments we already have
+            #   continue
+            _completions.append(_completion)
+        return json.dumps({'id': identifier, 'results': _completions})
+
+    def _serialize_arguments(self, script, identifier=None):
+        """Serialize response to be read from VSCode.
+
+        Args:
+            script: Instance of jedi.api.Script object.
+            identifier: Unique completion identifier to pass back to VSCode.
+
+        Returns:
+            Serialized string to send to VSCode.
+        """
+        return json.dumps({"id": identifier, "results" : self._get_call_signatures_with_args(script) })
+
+    def _get_call_signatures_jp(self, script):
+        """Extract call signatures from jedi.api.Script object in failsafe way.
+
+        Returns:
+            Dict representation of parts of signature needed by jedi-vim
+        """
+        _signatures = []
+        try:
+            call_signatures = script.call_signatures()
+        except KeyError:
+            call_signatures = []
+
+        for signature in call_signatures:
+            params = [{'description': p.description} for p in signature.params]
+            _signatures.append({
+                'params': params,
+                'bracket_start': signature.bracket_start,
+                'index': signature.index
+            })
+
+        return _signatures
+
+    def _serialize_signatures(self, script, identifier=None):
+        """Serialize call signatures to be read by jedi_client"""
+        return json.dumps({'id': identifier, 'results': self._get_call_signatures_jp(script)})
+
+    def _serialize_definitions(self, definitions, identifier=None):
+        """Serialize response to be read from VSCode.
+
+        Args:
+            definitions: List of jedi.api.classes.Definition objects.
+            identifier: Unique completion identifier to pass back to VSCode.
+
+        Returns:
+            Serialized string to send to VSCode.
+        """
+
+        def _top_definition(definition):
+          for d in definition.goto_assignments():
+            if d == definition:
+              continue
+            if d.type == 'import':
+              return _top_definition(d)
+            else:
+              return d
+          return definition
+
+        _definitions = []
+        for definition in definitions:
+            try:
+                if definition.module_path:
+                    if definition.type == 'import':
+                        definition = _top_definition(definition)
+
+                    _definition = {
+                        'text': definition.name,
+                        'type': self._get_definition_type(definition),
+                        'fileName': definition.module_path,
+                        'line': definition.line - 1,
+                        'column': definition.column
+                    }
+                    _definitions.append(_definition)
+            except Exception as e:
+                pass
+        return json.dumps({'id': identifier, 'results': _definitions})
+
+    def _serialize_usages(self, usages, identifier=None):
+      _usages = []
+      for usage in usages:
+        _usages.append({
+          'name': usage.name,
+          'moduleName': usage.module_name,
+          'fileName': usage.module_path,
+          'line': usage.line,
+          'column': usage.column,
+        })
+      return json.dumps({'id': identifier, 'results': _usages})
+
+    def _deserialize(self, request):
+        """Deserialize request from VSCode.
+
+        Args:
+            request: String with raw request from VSCode.
+
+        Returns:
+            Python dictionary with request data.
+        """
+        return json.loads(request)
+
+    def _set_request_config(self, config):
+        """Sets config values for current request.
+
+        This includes sys.path modifications which is getting restored to
+        default value on each request so each project should be isolated
+        from each other.
+
+        Args:
+            config: Dictionary with config values.
+        """
+        sys.path = self.default_sys_path
+        self.use_snippets = config.get('useSnippets')
+        self.show_doc_strings = config.get('showDescriptions', True)
+        self.fuzzy_matcher = config.get('fuzzyMatcher', False)
+        jedi.settings.case_insensitive_completion = config.get(
+            'caseInsensitiveCompletion', True)
+        for path in config.get('extraPaths', []):
+            if path and path not in sys.path:
+                sys.path.insert(0, path)
+
+    def _process_request(self, request):
+        """Accept serialized request from VSCode and write response.
+        """
+        request = self._deserialize(request)
+
+        self._set_request_config(request.get('config', {}))
+
+        path = self._get_top_level_module(request.get('path', ''))
+        if path not in sys.path:
+            sys.path.insert(0, path)
+        lookup = request.get('lookup', 'completions')
+
+        if lookup == 'names':
+            return self._write_response(self._serialize_definitions(
+                jedi.api.names(
+                    source=request.get('source', None),
+                    path=request.get('path', ''),
+                    all_scopes=True),
+                request['id']))
+
+        script = jedi.api.Script(
+            source=request.get('source', None), line=request['line'] + 1,
+            column=request['column'], path=request.get('path', ''))
+
+        if lookup == 'definitions':
+            return self._write_response(self._serialize_definitions(
+                script.goto_assignments(), request['id']))
+        elif lookup == 'arguments':
+            return self._write_response(self._serialize_arguments(
+                script, request['id']))
+        elif lookup == 'usages':
+            return self._write_response(self._serialize_usages(
+                script.usages(), request['id']))
+        elif lookup == 'signatures':
+            return self._write_response(self._serialize_signatures(
+                script, request['id']))
+        else:
+            return self._write_response(
+                self._serialize_completions(script, request['id'],
+                                            request.get('prefix', '')))
+
+    def _write_response(self, response):
+        sys.stdout.write(response + '\n')
+        sys.stdout.flush()
+        return response
+
+    def watch(self):
+        while True:
+            try:
+                self._process_request(self._input.readline())
+            except Exception:
+                sys.stdout.write('\n')
+                sys.stdout.flush()
+                sys.stderr.write(traceback.format_exc() + '\n')
+                sys.stderr.flush()
+
+if __name__ == '__main__':
+    JediCompletion().watch()

--- a/jedi_client.py
+++ b/jedi_client.py
@@ -1,0 +1,141 @@
+"""
+Remote jedi for jedi-vim
+
+Daniel Holth <dholth@gmail.com>, 2016
+"""
+
+__version__ = '0.9.0'
+
+import os.path
+import attr
+import subprocess
+import json
+
+import logging
+log = logging.getLogger(__name__)
+
+DEBUG = False
+
+if DEBUG:
+    log.setLevel(logging.DEBUG)
+    fh = logging.FileHandler('/tmp/jedi.log')
+    fh.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(message)s')
+    fh.setFormatter(formatter)
+    log.addHandler(fh)
+
+__here__ = os.path.dirname(__file__)
+
+class LineSubprocess(object):
+    def __init__(self):
+        import distutils.spawn
+        self.PYTHON = distutils.spawn.find_executable('python')
+        self._child = None
+
+    @property
+    def child(self):
+        if self._child == None or self._child.poll() != None:
+            self._child = subprocess.Popen([self.PYTHON, __here__], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        return self._child
+
+    def request(self, command):
+        """Send line to subprocess, returning one-line response."""
+        child = self.child
+        child.stdin.write(command.encode('utf-8') + b'\n')
+        child.stdin.flush()
+        return child.stdout.readline().decode('utf-8') # XXX timeout, subprocess MUST send \n and flush()
+        # XXX does subprocess need to do something to ensure utf-8 encoding?
+
+server = LineSubprocess()
+
+class Settings(object):
+    additional_dynamic_modules = attr.ib(default=[])
+
+settings = Settings()
+
+class NotFoundError(Exception):
+    # no longer used, but referenced
+    pass
+
+@attr.s
+class Completion(object):
+    name = attr.ib()
+    complete = attr.ib()
+    name_with_symbols = attr.ib()
+    description = attr.ib()
+    docstring_ = attr.ib()
+
+    def docstring(self):
+        return self.docstring_
+
+@attr.s
+class Param(object):
+    description = attr.ib()
+
+@attr.s(init=False)
+class CallSignature(object):
+    bracket_start = attr.ib()
+    index = attr.ib()
+    params = attr.ib(default=attr.Factory(list))
+
+    def __getattr__(self, key):
+        if not key in self.__dict__:
+            log.debug('getattr', key)
+        return self.__dict__[key]
+
+    def __init__(self, params=None, bracket_start=None, index=None):
+        self.params = [Param(p['description']) for p in params]
+        self.bracket_start = bracket_start
+        self.index = index
+
+@attr.s
+class Script(object):
+    sequence = 0
+
+    source = attr.ib(default=None)
+    line = attr.ib(default=None)
+    column = attr.ib(default=None)
+    path = attr.ib(default='')
+    encoding = attr.ib(default='utf-8')
+    source_path = attr.ib(default=None)
+    source_encoding = attr.ib(default=None)
+    id = attr.ib(default=0)
+
+    # manual __init__ won't work with attr.ib...
+
+    def request(self, lookup='completions'):
+        Script.sequence += 1
+        self.id = Script.sequence
+        try:
+            request_data = self.__dict__.copy()
+            request_data['line'] -= 1
+            request_data['lookup'] = lookup
+            request = json.dumps(request_data, sort_keys=True) # must be 1 line only
+            log.debug(request)
+            response = server.request(request)
+            log.debug("-> %s", response)
+            return json.loads(response)['results']
+        except Exception as e:
+            log.exception(e)
+
+    def completions(self):
+        results = self.request(lookup='completions')
+        completions = [Completion(**result) for result in results]
+        return completions
+
+    def call_signatures(self):
+        results = self.request(lookup='signatures')
+        signatures = [CallSignature(**result) for result in results]
+        return signatures
+
+    def goto_definitions(self):
+        result = self.request(lookup='definitions')
+        return []
+
+    def goto_assignments(self):
+        return []
+
+    def usages(self):
+        results = self.request(lookup='usages')
+        return []
+

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -94,11 +94,12 @@ def echo_highlight(msg):
 
 
 try:
-    import jedi
+    import jedi_client as jedi
 except ImportError as e:
     no_jedi_warning(str(e))
     jedi = None
-else:
+
+if False:
     try:
         version = jedi.__version__
     except Exception as e:  # e.g. AttributeError
@@ -110,8 +111,7 @@ else:
     else:
         if isinstance(version, str):
             # the normal use case, now.
-            from jedi import utils
-            version = utils.version_info()
+            version = tuple(map(int, version.split('.')))
         if version < (0, 7):
             echo_highlight('Please update your Jedi version, it is too old.')
 
@@ -625,7 +625,7 @@ def py_import():
 def py_import_completions():
     argl = vim.eval('a:argl')
     try:
-        import jedi
+        import jedi_client as jedi
     except ImportError:
         print('Pyimport completion requires jedi module: https://github.com/davidhalter/jedi')
         comps = []


### PR DESCRIPTION
Call jedi in a subprocess, executed with python on PATH.

This is a very messy prototype of calling Jedi in a subprocess, with less code running in the actual vim-embedded Python. PR for discussion only. I hope it is enough to demonstrate that doing a process split is not a big deal. Sorry that the vendored attrs library adds noise to the diff.

I wanted this to be able to use embedded-Python-3-only vim with Python 2 and importantly PyPy projects. I should probably just recompile vim myself, but I tried this.

The way it works is that jedi_client.py mocks the impressively small jedi API needed by jedi-vim. When you make a call it sends a line of JSON to the server, just a subprocess, which calls real jedi and writes a single line of JSON as the response. Just completions and signatures implemented so far.

If this was developed further then jedi-vim could stay the same, except that a configuration flag imports from jedi_client instead of jedi.