### PR TITLE
bugfix for goto(get_script)

### DIFF
--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -149,8 +149,10 @@ def get_script(source=None, column=None):
     if column is None:
         column = vim.current.window.cursor[1]
     buf_path = vim.current.buffer.name
+    if buf_path:
+        buf_path = buf_path.split("/")[-1]
     encoding = vim_eval('&encoding') or 'latin1'
-    return jedi.Script(source, row, column, buf_path.split("/")[-1], encoding)
+    return jedi.Script(source, row, column, buf_path, encoding)
 
 
 @_check_jedi_availability(show_error=False)

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -150,7 +150,7 @@ def get_script(source=None, column=None):
         column = vim.current.window.cursor[1]
     buf_path = vim.current.buffer.name
     encoding = vim_eval('&encoding') or 'latin1'
-    return jedi.Script(source, row, column, buf_path, encoding)
+    return jedi.Script(source, row, column, buf_path.split("/")[-1], encoding)
 
 
 @_check_jedi_availability(show_error=False)


### PR DESCRIPTION
My document structure：
|--A
|----__init__.py
|----a.py
|--B
|----__init__.py
|----b.py
add file content like:
a.py:
`def funa():
    pass
`
b.py:
`from a.aa import funa`

When my corsor on funa in b.py, I can't jump to funa() in a.py .
After change  to `return jedi.Script(source, row, column, buf_path.split("/")[-1], encoding)` i can jump !!!