### PR TITLE
Change default g:jedi#call_signature_escape to avoid collision

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -50,5 +50,6 @@ Dave Honneffer (@pearofducks)
 Bagrat Aznauryan (@n9code)
 Tomoyuki Kashiro (@kashiro)
 Tommy Allen (@tweekmonster)
+Mingliang (@Aulddays)
 
 @something are github user names.

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -27,7 +27,7 @@ let s:default_settings = {
     \ 'documentation_command': "'K'",
     \ 'show_call_signatures': 1,
     \ 'show_call_signatures_delay': 500,
-    \ 'call_signature_escape': "'=`='",
+    \ 'call_signature_escape': "'?!?'",
     \ 'auto_close_doc': 1,
     \ 'max_doc_height': 30,
     \ 'popup_select_first': 1,


### PR DESCRIPTION
Syntax highlighting on chars in g:jedi#call_signature_escape may
break the funciton parameter hint from jedi-vim. Change its default
value to non python syntax symbols to reduce chance of collision