### PR TITLE
automatic python version check is made async in neovim.

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -120,21 +120,71 @@ function! jedi#reinit_python()
     call jedi#init_python()
 endfunction
 
+fun! s:async_init()
+    if g:jedi#force_py_version != 'auto'
+        " Always use the user supplied version.
+            call s:next_action(g:jedi#force_py_version)
+    endif
+
+    " Handle "auto" version.
+    if has('nvim') || (has('python') && has('python3'))
+        " Neovim usually has both python providers. Skipping the `has` check
+        " avoids starting both of them.
+
+        fun! s:JobHandler(jobid, data, event)
+            if a:event == 'stdout'
+                let s:def_py = a:data[0]
+                if &verbose
+                    echom "jedi-vim: auto-detected Python: ".s:def_py
+                endif
+            elseif a:event == 'stderr'
+                if !exists("g:jedi#squelch_py_warning")
+                    echohl WarningMsg
+                    echom "Warning: jedi-vim failed to get Python version from sys.version_info: " . s:def_py
+                    echom "Falling back to version 2."
+                    echohl None
+                endif
+                let s:def_py = 2
+            else
+                return
+            endif
+            call s:next_action(s:def_py)
+        endf
+        let s:handlers = {'on_stdout': function('s:JobHandler'), 'on_stderr': function('s:JobHandler'), 'on_exit': function('s:JobHandler')}
+        call jobstart('python -c '.shellescape('import sys; print(str(sys.version_info[0]))'), s:handlers)
+    endif
+endf
+
+fun! s:next_action(py_version)
+    try
+        let s:_init_python = jedi#force_py_version(a:py_version)
+    catch
+        let s:_init_python = 0
+        if !exists("g:jedi#squelch_py_warning")
+            echoerr "Error: jedi-vim failed to initialize Python: "
+                        \ .v:exception." (in ".v:throwpoint.")"
+        endif
+    endtry
+endf
 
 let s:_init_python = -1
 function! jedi#init_python()
     if s:_init_python == -1
-        try
-            let s:_init_python = s:init_python()
-        catch
-            let s:_init_python = 0
-            if !exists("g:jedi#squelch_py_warning")
-                echoerr "Error: jedi-vim failed to initialize Python: "
-                            \ .v:exception." (in ".v:throwpoint.")"
-            endif
-        endtry
+        if has('nvim')
+            call s:async_init()
+        else
+            try
+                let s:_init_python = s:init_python()
+            catch
+                let s:_init_python = 0
+                if !exists("g:jedi#squelch_py_warning")
+                    echoerr "Error: jedi-vim failed to initialize Python: "
+                                \ .v:exception." (in ".v:throwpoint.")"
+                endif
+            endtry
+        endif
     endif
-    return s:_init_python
+    return 1
 endfunction
 
 

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -63,6 +63,7 @@ function! s:init_python()
         try
             return jedi#force_py_version(g:jedi#force_py_version)
         catch
+            echom "error"
             throw "Could not setup g:jedi#force_py_version: ".v:exception
         endtry
     endif
@@ -143,7 +144,8 @@ endf
 fun! s:async_init()
     if g:jedi#force_py_version != 'auto'
         " Always use the user supplied version.
-            call s:next_action(g:jedi#force_py_version)
+        call s:next_action(g:jedi#force_py_version)
+        return
     endif
 
     " Handle "auto" version.


### PR DESCRIPTION
The code is a bit messy, because of my lack of knowledge of vimscript. The problem is that the python version check which was done via `system` call have taken previously half a second which is more or less equal to the time that takes loading everything else including.

With neovim jobcontrol this time reduced to about 80 ms (probably could be improved more, but good enough for me).

The basic idea here is to turn normal code into continuation passing style (which is the only option, because AFAIK vimscript doesn't have any other means for asynchronous code.

You could add vim8 support to that and make proper continuation passing. Right now I've just hardcoded what function to execute if python version check script returned something `s:next_action`.