### PR TITLE
Only remap `.` if both completions and popup_on_dot are enabled.

### DIFF
--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -33,7 +33,7 @@ if g:jedi#auto_initialization
         call jedi#configure_call_signatures()
     endif
 
-    if g:jedi#completions_enabled == 1
+    if g:jedi#completions_enabled == 1 && g:jedi#popup_on_dot == 1
         inoremap <silent> <buffer> . .<C-R>=jedi#complete_string(1)<CR>
     endif
 


### PR DESCRIPTION
Hello,

Current behaviour would otherwise overwrite any custom vimrc mappings on `.`, regardless of whether or not `g:jedi#popup_on_dot` is set to 0 - this commit addresses that issue.

Cheers,
Thaer