### PR TITLE
Move Travis targets to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,9 @@ matrix:
     - env: ENV=test
 install:
   - |
-    if [ "$ENV" = "check" ]; then
-      pip install vim-vint
-    else
+    if [ "$ENV" = "test" ]; then
       pip install pytest
     fi
 script:
   - vim --version
-  - |
-    if [ "$ENV" = "check" ]; then
-      vint after autoload ftplugin plugin
-    else
-      pytest
-    fi
+  - make "$ENV"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+test:
+	py.test
+
+build:
+	mkdir $@
+build/vint: | build
+	virtualenv $@
+	$@/bin/pip install vim-vint
+check: LINT_FILES:=after autoload ftplugin plugin
+check: build/vint
+	build/vint/bin/vint $(LINT_FILES)
+
+clean:
+	rm -rf .cache build
+
+.PHONY: test check clean


### PR DESCRIPTION
This allows for calling them easily locally.

Downside: puts installation of `vint` into the `script` part of the Travis job.