### PR TITLE
Fixes #671

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -51,5 +51,6 @@ Bagrat Aznauryan (@n9code)
 Tomoyuki Kashiro (@kashiro)
 Tommy Allen (@tweekmonster)
 Mingliang (@Aulddays)
+Pablo galindo (@pablogsal)
 
 @something are github user names.

--- a/jedi_vim.py
+++ b/jedi_vim.py
@@ -567,7 +567,7 @@ def do_rename(replace, orig=None):
     # Sort the whole thing reverse (positions at the end of the line
     # must be first, because they move the stuff before the position).
     temp_rename = sorted(temp_rename, reverse=True,
-                         key=lambda x: (x.module_path, x.start_pos))
+                         key=lambda x: (x.module_path, (x.line,x.column)))
     buffers = set()
     for r in temp_rename:
         if r.in_builtin_module():
@@ -585,7 +585,7 @@ def do_rename(replace, orig=None):
         saved_view = vim_eval('string(winsaveview())')
 
         # Replace original word.
-        vim.current.window.cursor = r.start_pos
+        vim.current.window.cursor = (r.line, r.column)
         vim_command('normal! c{0:d}l{1}'.format(len(orig), replace))
 
         # Restore view.


### PR DESCRIPTION
Fix deprecated API for BaseDefinition class in Jedi.

The old interface to the position was:

`BaseDefinition.start_pos`

Now the same attribute in placed in the private attribute:

`BaseDefinition._name.start_pos`

that now can be acceded by the properties:

`BaseDefinition.line`
`BaseDefinition.column`

So the solution is to use the tuple:

`(BaseDefinition.module_path, BaseDefinition.start_pos)`.