### PR TITLE
popup_on_dot: document that it needs completions_enabled

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -23,7 +23,8 @@ let s:default_settings = {
     \ 'call_signatures_command': "'<leader>n'",
     \ 'usages_command': "'<leader>n'",
     \ 'rename_command': "'<leader>r'",
-    \ 'popup_on_dot': 1,
+    \ 'completions_enabled': 1,
+    \ 'popup_on_dot': 'g:jedi#completions_enabled',
     \ 'documentation_command': "'K'",
     \ 'show_call_signatures': 1,
     \ 'show_call_signatures_delay': 500,
@@ -32,7 +33,6 @@ let s:default_settings = {
     \ 'max_doc_height': 30,
     \ 'popup_select_first': 1,
     \ 'quickfix_window_height': 10,
-    \ 'completions_enabled': 1,
     \ 'force_py_version': "'auto'",
     \ 'smart_auto_mappings': 1,
     \ 'use_tag_stack': 1

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -373,6 +373,7 @@ However, when working with large modules, this can slow down your typing flow
 since you have to wait for jedi to parse the module and show the completion
 menu. By disabling this setting, completion is only started when you manually
 press the completion key.
+You need to also have `g:jedi#completions_enabled` enabled for this.
 
 Options: 0 or 1
 Default: 1 (Start completion on typing a period)


### PR DESCRIPTION
It would be ignored already with completions_enabled=0.
This documents it and makes the default follow it.