### PR TITLE
Fix unwanted fold in __doc__

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -373,6 +373,7 @@ function! jedi#show_documentation() abort
     setlocal nomodifiable
     setlocal nomodified
     setlocal filetype=rst
+    setlocal foldlevel=200 " do not fold in __doc__
 
     if l:doc_lines > g:jedi#max_doc_height " max lines for plugin
         let l:doc_lines = g:jedi#max_doc_height


### PR DESCRIPTION
I am using https://github.com/Rykka/riv.vim as the rst plugin, it fold rst file automatically.  
This also affects the `__doc__` buffer of python, because its filetype is rst.  
I don't think we need fold in `__doc__`, because it's usually short.