### PR TITLE
Define PythonJedi command always

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -152,12 +152,12 @@ function! jedi#setup_py_version(py_version) abort
         throw 'jedi#setup_py_version: invalid py_version: '.a:py_version
     endif
 
+    execute 'command! -nargs=1 PythonJedi '.cmd_exec.' <args>'
     try
         execute cmd_init.' '.s:script_path.'/initialize.py'
     catch
         throw 'jedi#setup_py_version: '.v:exception
     endtry
-    execute 'command! -nargs=1 PythonJedi '.cmd_exec.' <args>'
     return 1
 endfunction
 


### PR DESCRIPTION
This is meant to help in case of issues where the Python initialization
fails (https://github.com/davidhalter/jedi-vim/issues/726#issue-248054145),
so that `JediDebuginfo` can still provide some more information.