### PR TITLE
Use Vim's pythonx mechanism

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jedi"]
-	path = jedi
+	path = pythonx/jedi
 	url = https://github.com/davidhalter/jedi.git

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -93,6 +93,9 @@ def echo_highlight(msg):
         str(msg).replace('"', '\\"')))
 
 
+jedi_path = os.path.join(os.path.dirname(__file__), 'jedi')
+sys.path.insert(0, jedi_path)
+
 try:
     import jedi
 except ImportError as e:
@@ -115,6 +118,8 @@ else:
             version = utils.version_info()
         if version < (0, 7):
             echo_highlight('Please update your Jedi version, it is too old.')
+finally:
+    sys.path.remove(jedi_path)
 
 
 def catch_and_print_exceptions(func):


### PR DESCRIPTION
Move jedi_vim.py and the jedi submodule into pythonx, which gets added
to Vim's internal sys.path.  While jedi cannot be imported directly from
there, it still makes sense for consistency.