### PR TITLE
Move Python code for jedi#debug_info into pythonx

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -202,28 +202,8 @@ function! jedi#debug_info() abort
       endif
       echohl None
     else
-      PythonJedi << EOF
-vim.command("echo printf(' - sys.version: `%s`', {0!r})".format(', '.join([x.strip() for x in __import__('sys').version.split('\n')])))
-vim.command("echo printf(' - site module: `%s`', {0!r})".format(__import__('site').__file__))
-
-try:
-  jedi_vim
-except Exception as e:
-  vim.command("echo printf('ERROR: jedi_vim is not available: %s: %s', {0!r}, {1!r})".format(e.__class__.__name__, str(e)))
-else:
-  try:
-    if jedi_vim.jedi is None:
-      vim.command("echo 'ERROR: the \"jedi\" Python module could not be imported.'")
-      vim.command("echo printf('       The error was: %s', {0!r})".format(getattr(jedi_vim, "jedi_import_error", "UNKNOWN")))
-    else:
-      vim.command("echo printf('Jedi path: `%s`', {0!r})".format(jedi_vim.jedi.__file__))
-      vim.command("echo printf(' - version: %s', {0!r})".format(jedi_vim.jedi.__version__))
-      vim.command("echo ' - sys_path:'")
-      for p in jedi_vim.jedi.Script('')._evaluator.sys_path:
-        vim.command("echo printf('    - `%s`', {0!r})".format(p))
-  except Exception as e:
-    vim.command("echo printf('There was an error accessing jedi_vim.jedi: %s', {0!r})".format(e))
-EOF
+      PythonJedi from jedi_vim_debug import display_debug_info
+      PythonJedi display_debug_info()
     endif
     echo ' - jedi-vim git version: '
     echon substitute(system('git -C '.s:script_path.' describe --tags --always --dirty'), '\v\n$', '', '')

--- a/pythonx/jedi_vim_debug.py
+++ b/pythonx/jedi_vim_debug.py
@@ -1,0 +1,38 @@
+"""Used in jedi-vim's jedi#debug_info()"""
+
+
+def display_debug_info():
+    import vim
+
+    def echo(msg):
+        vim.command('echo {0}'.format(msg))
+
+    echo("printf(' - sys.version: `%s`', {0!r})".format(
+        ', '.join([x.strip()
+                   for x in __import__('sys').version.split('\n')])))
+    echo("printf(' - site module: `%s`', {0!r})".format(
+        __import__('site').__file__))
+
+    try:
+        import jedi_vim
+    except Exception as e:
+        echo("printf('ERROR: jedi_vim is not available: %s: %s', "
+             "{0!r}, {1!r})".format(e.__class__.__name__, str(e)))
+        return
+
+    try:
+        if jedi_vim.jedi is None:
+            echo("'ERROR: could not import the \"jedi\" Python module.'")
+            echo("printf('       The error was: %s', {0!r})".format(
+                getattr(jedi_vim, "jedi_import_error", "UNKNOWN")))
+        else:
+            echo("printf('Jedi path: `%s`', {0!r})".format(
+                jedi_vim.jedi.__file__))
+            echo("printf(' - version: %s', {0!r})".format(
+                jedi_vim.jedi.__version__))
+            echo("' - sys_path:'")
+            for p in jedi_vim.jedi.Script('')._evaluator.sys_path:
+                echo("printf('    - `%s`', {0!r})".format(p))
+    except Exception as e:
+        echo("printf('There was an error accessing jedi_vim.jedi: %s', "
+             "{0!r})".format(e))


### PR DESCRIPTION
This allows vimlparser to parse the vim file again, and it is more
convenient to have it in a real Python file anyway.

Small refactoring and minor text changes included.