### PR TITLE
fix: CheckHealth doesn't work in neovim

### DIFF
--- a/pythonx/jedi_vim_debug.py
+++ b/pythonx/jedi_vim_debug.py
@@ -31,7 +31,13 @@ def display_debug_info():
             echo("printf(' - version: %s', {0!r})".format(
                 jedi_vim.jedi.__version__))
             echo("' - sys_path:'")
-            for p in jedi_vim.jedi.Script('')._evaluator.project.sys_path:
+
+            script_evaluator = jedi_vim.jedi.Script('')._evaluator
+            try:
+                sys_path = script_evaluator.project.sys_path
+            except AttributeError:
+                sys_path = script_evaluator.sys_path
+            for p in sys_path:
                 echo("printf('    - `%s`', {0!r})".format(p))
     except Exception as e:
         echo("printf('There was an error accessing jedi_vim.jedi: %s', "

--- a/pythonx/jedi_vim_debug.py
+++ b/pythonx/jedi_vim_debug.py
@@ -31,7 +31,7 @@ def display_debug_info():
             echo("printf(' - version: %s', {0!r})".format(
                 jedi_vim.jedi.__version__))
             echo("' - sys_path:'")
-            for p in jedi_vim.jedi.Script('')._evaluator.sys_path:
+            for p in jedi_vim.jedi.Script('')._evaluator.project.sys_path:
                 echo("printf('    - `%s`', {0!r})".format(p))
     except Exception as e:
         echo("printf('There was an error accessing jedi_vim.jedi: %s', "


### PR DESCRIPTION
Hi. I found CheckHealth bug in neovim.
CheckHealth calls `display_debug_info()`.
However, error occured when loading `jedi_vim.jedi.Script('')._evaluator.sys_path`,
because `Evaluator.sys_path` is unavailable variable.