### PR TITLE
[IMP] README.rst - Add a description for Vundle installation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,14 @@ Example installation command using Pathogen:
 
     git clone --recursive https://github.com/davidhalter/jedi-vim.git ~/.vim/bundle/jedi-vim
 
+Example installation using Vundle:
+
+Add the following line in you `~/.vimrc`
+    
+.. code-block:: vim
+
+    Plugin 'davidhalter/jedi-vim'
+
 
 Installation with your distribution
 -----------------------------------

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Example installation command using Pathogen:
 
 Example installation using Vundle:
 
-Add the following line in you `~/.vimrc`
+Add the following line in your `~/.vimrc`
     
 .. code-block:: vim
 


### PR DESCRIPTION
Hi !
As @zwidny noticed in #748, there is no description in the README for Vundle install type.
This pr just adds the missing description.
Would not it be better to add a dedicated subsection for Vundle install type ?