### PR TITLE
get_script: additional_dynamic_modules: add only listed buffers

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -150,8 +150,11 @@ def _check_jedi_availability(show_error=False):
 
 @catch_and_print_exceptions
 def get_script(source=None, column=None):
-    jedi.settings.additional_dynamic_modules = \
-        [b.name for b in vim.buffers if b.name is not None and b.name.endswith('.py')]
+    jedi.settings.additional_dynamic_modules = [
+        b.name for b in vim.buffers if (
+            b.name is not None and
+            b.name.endswith('.py') and
+            b.options['buflisted'])]
     if source is None:
         source = '\n'.join(vim.current.buffer)
     row = vim.current.window.cursor[0]


### PR DESCRIPTION
Unlisted buffers might come e.g. from `set viminfo+=%`, and Jedi would
crash on them.

This could additionally check for them to be readable, but this should
be handled in Jedi itself anyway.