### PR TITLE
Modified jedi version to autocomplete Gtk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "jedi"]
 	path = pythonx/jedi
-	url = https://github.com/davidhalter/jedi.git
+	url = https://github.com/albfan/jedi.git
 [submodule "pythonx/parso"]
 	path = pythonx/parso
 	url = https://github.com/davidhalter/parso.git


### PR DESCRIPTION
This is just a quick implementation to allow vim to autocomplete GObject introspection

But adding `import gi` to pythonx code for this plugin, leads to:

```
"meld/filediff.py" 2020L, 84352C
Please install Jedi if you want to use jedi-vim.
The error was: /usr/lib/python3.6/site-packages/gi/_gi.cpython-36m-x86_64-linux-gnu.so: undefined symbol: PyUnicode_FromFormat
Please install Jedi if you want to use jedi-vim.
The error was: /usr/lib/python3.6/site-packages/gi/_gi.cpython-36m-x86_64-linux-gnu.so: undefined symbol: PyUnicode_FromFormat
```

Maybe I can fix this with `pythonthreedll` I'm really not sure

If it helps, here is `JediDebugInfo`

```
:JediDebugInfo
#### Jedi-vim debug information
Using Python version: 3
 - global sys.version: `3.6.5 (default, May 11 2018, 04:00:52), [GCC 8.1.0]`
 - global site module: `/usr/lib/python3.6/site.py`
ERROR: could not import the "jedi" Python module.
       The error was: /usr/lib/python3.6/site-packages/gi/_gi.cpython-36m-x86_64-linux-gnu.so: undefined symbol: PyUnicode_FromFormat
 - jedi-vim git version: 0.9.0-22-geaecae4
 - jedi git submodule status:  370dcdbf9a618f77cfde7098bcbe88193269302b pythonx/jedi (v0.12.0-1-g370dcdbf)
 6f385bdba182059e0c46917a414981a6d0894527 pythonx/parso (v0.2.1)

##### Settings
``
g:jedi#force_py_version = 3 (default: 'auto')

  omnifunc=jedi#completions
        Se definió por última vez en ~/.vim/bundle/jedi-vim/autoload/jedi.vim
  completeopt=menuone,longest,preview
        Se definió por última vez en ~/.vim/bundle/jedi-vim/plugin/jedi.vim
``

```