### PR TITLE
show_call_signatures: skip empty params

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -491,6 +491,10 @@ def show_call_signatures(signatures=()):
         # Descriptions are usually looking like `param name`, remove the param.
         params = [p.description.replace('\n', '').replace('param ', '', 1)
                   for p in signature.params]
+        if params == ['']:
+            # This is the case with `Exception(` for example.
+            # It makes no sense to display `()` then.
+            return
         try:
             # *_*PLACEHOLDER*_* makes something fat. See after/syntax file.
             params[signature.index] = '*_*%s*_*' % params[signature.index]


### PR DESCRIPTION
Not sure if sigs for `Exception()` can be improved, but this patch handles this case in general.

FWIW, ipython displays the following for `Exception?`:
```
Init signature: Exception(self, /, *args, **kwargs)
Docstring:      Common base class for all non-exit exceptions.
Type:           type
```