### PR TITLE
Skip duplicate call signatures

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -475,6 +475,7 @@ def show_call_signatures(signatures=()):
     if int(vim_eval("g:jedi#show_call_signatures")) == 2:
         return cmdline_call_signatures(signatures)
 
+    seen_sigs = []
     for i, signature in enumerate(signatures):
         line, column = signature.bracket_start
         # signatures are listed above each other
@@ -496,6 +497,11 @@ def show_call_signatures(signatures=()):
             params[signature.index] = '*_*%s*_*' % params[signature.index]
         except (IndexError, TypeError):
             pass
+
+        # Skip duplicates.
+        if params in seen_sigs:
+            continue
+        seen_sigs.append(params)
 
         # This stuff is reaaaaally a hack! I cannot stress enough, that
         # this is a stupid solution. But there is really no other yet.


### PR DESCRIPTION
I am seeing `p` twice for os.path.dirname, which seems to come from
Lib/posixpath.py and Lib/ntpath.py, as can be seen with `os.path.join`,
where I still see two with this patch:

```
            (path, *paths)
import os   (a, *p)
os.path.join()
```

btw: I had a hard time (i.e. failed) to get the filename information for the underlying definitions.
I think it might be useful to add additional information to the call signature in case there are multiple signatures and they are coming from different files/modules maybe?