### PR TITLE
[RFC] Revisit usage highlighting

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -471,10 +471,14 @@ function! jedi#add_goto_window(for_usages, len, ...) abort
 
     " Using :cwindow allows to stay in the current window in case it is opened
     " already.
+    let win_count = winnr('$')
     execute 'belowright cwindow '.height
+    let qfwin_was_opened = winnr('$') > win_count
 
-    if &filetype ==# 'qf'
-        " Setup quickfix window (initially, when opened via ":cwindow" above).
+    if qfwin_was_opened
+        if &filetype !=# 'qf'
+            echoerr 'jedi-vim: unexpected ft with current window, please report!'
+        endif
         if g:jedi#use_tabs_not_buffers == 1
             noremap <buffer> <CR> :call jedi#goto_window_on_enter()<CR>
         endif

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -489,9 +489,6 @@ function! jedi#add_goto_window(for_usages, len) abort
                 autocmd WinLeave <buffer> q  " automatically leave, if an option is chosen
             endif
         augroup END
-
-        " Preview
-        " exe "nnoremap <buffer> p \<CR>:PythonJedi jedi_vim.highlight_usages_for_vim_win()\<CR>\<C-w>p"
     elseif a:for_usages && !s:supports_buffer_usages
         " Init current window.
         call jedi#_show_usages_in_win()

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -461,8 +461,7 @@ endfunction
 " helper functions
 " ------------------------------------------------------------------------
 
-" a:mode: 'goto' or 'usages'
-function! jedi#add_goto_window(mode, len, ...) abort
+function! jedi#add_goto_window(for_usages, len, ...) abort
     let select_entry = a:0 ? a:1 : 0
     let height = min([a:len, g:jedi#quickfix_window_height])
 
@@ -477,10 +476,10 @@ function! jedi#add_goto_window(mode, len, ...) abort
         endif
 
         augroup jedi_goto_window
-            if a:mode ==# 'goto'
-                autocmd WinLeave <buffer> q  " automatically leave, if an option is chosen
-            else
+            if a:for_usages
                 autocmd BufWinLeave <buffer> call jedi#clear_usages()
+            else
+                autocmd WinLeave <buffer> q  " automatically leave, if an option is chosen
             endif
         augroup END
 
@@ -490,12 +489,12 @@ function! jedi#add_goto_window(mode, len, ...) abort
         if select_entry > 1
             exe select_entry.'cc'
         endif
-    elseif !has('nvim') && a:mode ==# 'usages'
+    elseif !has('nvim') && a:for_usages
         " Init current window.
         call jedi#show_usages_in_win()
     endif
 
-    if a:mode ==# 'usages'
+    if a:for_usages
         if has('nvim')
             augroup jedi_usages
               autocmd! BufWinEnter * call s:usages_for_buffer_nvim()

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -465,8 +465,7 @@ endfunction
 " helper functions
 " ------------------------------------------------------------------------
 
-function! jedi#add_goto_window(for_usages, len, ...) abort
-    let select_entry = a:0 ? a:1 : 0
+function! jedi#add_goto_window(for_usages, len) abort
     let height = min([a:len, g:jedi#quickfix_window_height])
 
     " Using :cwindow allows to stay in the current window in case it is opened
@@ -493,10 +492,6 @@ function! jedi#add_goto_window(for_usages, len, ...) abort
 
         " Preview
         " exe "nnoremap <buffer> p \<CR>:PythonJedi jedi_vim.highlight_usages_for_vim_win()\<CR>\<C-w>p"
-
-        if select_entry > 1
-            exe select_entry.'cc'
-        endif
     elseif a:for_usages && !s:supports_buffer_usages
         " Init current window.
         call jedi#_show_usages_in_win()

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -470,7 +470,7 @@ function! jedi#add_goto_window(for_usages, len, ...) abort
     execute 'belowright cwindow '.height
 
     if &filetype ==# 'qf'
-        " Setup quickfix window, but only if it was opened / initially.
+        " Setup quickfix window (initially, when opened via ":cwindow" above).
         if g:jedi#use_tabs_not_buffers == 1
             noremap <buffer> <CR> :call jedi#goto_window_on_enter()<CR>
         endif

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -50,8 +50,4 @@ if g:jedi#auto_initialization
             autocmd! InsertLeave <buffer> if pumvisible() == 0|pclose|endif
         augroup END
     endif
-    augroup jedi_usages
-        autocmd! TextChanged <buffer> call jedi#remove_usages()
-        autocmd! InsertEnter <buffer> call jedi#remove_usages()
-    augroup END
 endif

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -414,7 +414,7 @@ def usages(visuals=True):
     return definitions
 
 
-_current_highlights = None
+_current_definitions = None
 """Current definitions to use for highlighting."""
 
 
@@ -433,10 +433,10 @@ else:
 
 def clear_usages():
     """Clear existing highlights."""
-    global _current_highlights
-    if _current_highlights is None:
+    global _current_definitions
+    if _current_definitions is None:
         return
-    _current_highlights = None
+    _current_definitions = None
 
     if IS_NVIM:
         for buf in vim.buffers:
@@ -462,10 +462,10 @@ def highlight_usages(definitions):
     windows on demand.  Otherwise Vim's text-properties are used.
     """
 
-    global _current_highlights
+    global _current_definitions
     if definitions:
-        assert not _current_highlights
-    _current_highlights = definitions
+        assert not _current_definitions
+    _current_definitions = definitions
 
     if IS_NVIM or vim_prop_add:
         bufs = {x.name: x for x in vim.buffers}
@@ -493,8 +493,8 @@ def highlight_usages(definitions):
 
 
 def highlight_usages_for_buf():
-    global _current_highlights
-    definitions = _current_highlights
+    global _current_definitions
+    definitions = _current_definitions
 
     buf = vim.current.buffer
     bufname = buf.name
@@ -545,8 +545,8 @@ def highlight_usages_for_vim_win():
 
     (matchaddpos() only works for the current window.)
     """
-    global _current_highlights
-    definitions = _current_highlights
+    global _current_definitions
+    definitions = _current_definitions
 
     win = vim.current.window
 

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -418,11 +418,7 @@ _current_highlights = (None, None)
 """Current (definitions, length) to use for highlighting."""
 
 
-try:
-    import neovim  # noqa: F401
-    HAS_NVIM = True
-except ImportError:
-    HAS_NVIM = False
+IS_NVIM = hasattr(vim, 'from_nvim')
 
 
 def clear_usages():
@@ -432,7 +428,7 @@ def clear_usages():
         return
     _current_highlights = (None, None)
 
-    if HAS_NVIM:
+    if IS_NVIM:
         for buf in vim.buffers:
             src_ids = buf.vars.get('_jedi_usages_src_ids')
             if src_ids is not None:
@@ -457,7 +453,7 @@ def highlight_usages(definitions, length=None):
         assert not _current_highlights[0]
     _current_highlights = (definitions, length)
 
-    if HAS_NVIM:
+    if IS_NVIM:
         bufs = {x.name: x for x in vim.buffers}
         buf_src_ids = {}
         for definition in definitions:
@@ -480,7 +476,7 @@ def highlight_usages_for_buf():
     global _current_highlights
     (definitions, length) = _current_highlights
 
-    assert HAS_NVIM
+    assert IS_NVIM
 
     buf = vim.current.buffer
     bufname = buf.name

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -397,7 +397,7 @@ def goto(mode="goto"):
                                     repr(PythonToVimStr(old_wildignore)))
             vim.current.window.cursor = d.line, d.column
     else:
-        show_goto_multi_results(definitions, False)
+        show_goto_multi_results(definitions, mode)
     return definitions
 
 

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -409,8 +409,8 @@ def usages(visuals=True):
         return definitions
 
     if visuals:
-        highlight_usages(definitions)
         show_goto_multi_results(definitions, True)
+        highlight_usages(definitions)
     return definitions
 
 

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -155,7 +155,6 @@ class VimCompat:
                 f = cls._func_cache[func] = getattr(vim.funcs, func)
             else:
                 f = cls._func_cache[func] = vim.Function(func)
-        print(f, args)
         return f(*args)
 
     @classmethod

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -443,9 +443,8 @@ def show_goto_multi_results(definitions, mode):
     VimCompat.setqflist(lst, title=qftitle)
 
     for_usages = mode == "usages"
-    vim_eval('jedi#add_goto_window(%d, %d, %d)' % (
-        for_usages, len(lst), select_entry,
-    ))
+    vim_eval('jedi#add_goto_window(%d, %d)' % (for_usages, len(lst)))
+    vim_command('%dcc' % select_entry)
 
 
 @catch_and_print_exceptions

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -345,7 +345,7 @@ def goto(mode="goto"):
                                     repr(PythonToVimStr(old_wildignore)))
             vim.current.window.cursor = d.line, d.column
     else:
-        show_goto_multi_results(definitions, 'goto')
+        show_goto_multi_results(definitions, False)
     return definitions
 
 
@@ -370,7 +370,7 @@ def annotate_description(d):
     return '[%s] %s' % (typ, code)
 
 
-def show_goto_multi_results(definitions, mode):
+def show_goto_multi_results(definitions, for_usages):
     """Create a quickfix list for multiple definitions."""
     lst = []
     (row, col) = vim.current.window.cursor
@@ -395,9 +395,9 @@ def show_goto_multi_results(definitions, mode):
 
     vim_eval('setqflist(%s)' % repr(lst))
     if current_idx is not None:
-        vim_eval('jedi#add_goto_window(%r, %d, %d)' % (mode, len(lst), current_idx))
+        vim_eval('jedi#add_goto_window(%d, %d, %d)' % (for_usages, len(lst), current_idx))
     else:
-        vim_eval('jedi#add_goto_window(%r, %d)' % (mode, len(lst),))
+        vim_eval('jedi#add_goto_window(%d, %d)' % (for_usages, len(lst),))
 
 
 @catch_and_print_exceptions
@@ -410,7 +410,7 @@ def usages(visuals=True):
 
     if visuals:
         highlight_usages(definitions)
-        show_goto_multi_results(definitions, 'usages')
+        show_goto_multi_results(definitions, True)
     return definitions
 
 

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -412,6 +412,7 @@ def show_goto_multi_results(definitions, mode):
     lst = []
     (row, col) = vim.current.window.cursor
     current_idx = None
+    current_def = None
     for d in definitions:
         if d.column is None:
             # Typically a namespace, in the future maybe other things as
@@ -429,12 +430,12 @@ def show_goto_multi_results(definitions, mode):
                         or (abs(lst[current_idx].column - col)
                             > abs(d.column - col))):
                     current_idx = len(lst)
+                    current_def = d
 
     # Build qflist title.
     qftitle = mode
-    if current_idx is not None:
-        current = lst[current_idx]
-        qftitle += ": " + str(current['text'])
+    if current_def is not None:
+        qftitle += ": " + current_def.full_name
         select_entry = current_idx
     else:
         select_entry = 0

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -401,7 +401,7 @@ def usages(visuals=True):
     return definitions
 
 
-_current_highlights = None
+_current_highlights = (None, None)
 """Current (definitions, length) to use for highlighting."""
 
 
@@ -421,13 +421,13 @@ def highlight_usages_for_win():
     (matchaddpos() only works for the current window.)
     """
     global _current_highlights
-
-    if _current_highlights is None:
+    if _current_highlights[0] is None:
         print('jedi-vim: called highlight_usages_for_win without highlights!')
         return
 
-    if '_jedi_usages_matchids' in vim.current.window.vars:
-        for matchid in vim.current.window.vars['_jedi_usages_matchids']:
+    cur_matchids = vim.current.window.vars.get('_jedi_usages_matchids')
+    if cur_matchids:
+        for matchid in cur_matchids:
             expr = 'matchdelete(%d)' % int(matchid)
             vim.eval(expr)
 
@@ -445,8 +445,9 @@ def highlight_usages_for_win():
             expr = "matchaddpos('jediUsage', %s)" % repr(positions)
             matchids.append(vim_eval(expr))
 
-    if matchids:
-        vim.current.window.vars['_jedi_usages_matchids'] = matchids
+    # Always set it (uses an empty list for "unset", which is not possible
+    # using del).
+    vim.current.window.vars['_jedi_usages_matchids'] = matchids
 
 
 @_check_jedi_availability(show_error=True)

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -521,7 +521,9 @@ def highlight_usages(definitions):
     """
     global _current_definitions, _pending_definitions
     if definitions:
-        assert not _current_definitions
+        # TODO(blueyed): reuse / keep current qflist when it's the same again,
+        # but only with a different selected entry.
+        clear_usages()
     _current_definitions = definitions
     _pending_definitions = {}
 

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -521,9 +521,7 @@ def highlight_usages(definitions):
     """
     global _current_definitions, _pending_definitions
     if definitions:
-        # TODO(blueyed): reuse / keep current qflist when it's the same again,
-        # but only with a different selected entry.
-        clear_usages()
+        assert not _current_definitions
     _current_definitions = definitions
     _pending_definitions = {}
 


### PR DESCRIPTION
Pretty messy still (at least from the code), but some benefits:

- keeps definitions around until some text is changed (or the quickfix window is closed)
- keeps the qf window open on winleave
- uses `:cwindow` and no `:cclose` for better qf behavior in general, also gets rid of redraw! etc
- adds `p` for preview, although I find (mapped) `:cnext` etc better
- stores the actual matchids with the window

TODO:

- [x] text-properties instead of `matchaddpos()` (limited to current window) for Vim?