### PR TITLE
Test with Neovim also

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,20 @@ env:
   matrix:
     - ENV=test
     - ENV=check
+    - ENV=test_nvim
 install:
   - |
     if [ "$ENV" = "test" ]; then
       python3.6 -m pip install pytest
     fi
+  - |
+    # https://github.com/neovim/bot-ci#generated-builds
+    if [ "$ENV" = "test_nvim" ]; then
+      eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
+      pip --version
+      pip install neovim
+    else
+      vim --version
+    fi
 script:
-  - vim --version
   - make --keep-going "$ENV"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	pytest test_*.py
 
+test_nvim:
+	VSPEC_VIM=nvim pytest test_*.py
+
 build:
 	mkdir $@
 

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -94,7 +94,7 @@ describe 'signatures'
             return msg
         endfunction
 
-        let funcname = repeat('a', &columns - 30)
+        let funcname = repeat('a', &columns - (30 + (&ruler ? 18 : 0)))
         put = 'def '.funcname.'(arg1, arg2, arg3, a, b, c):'
         put = '    pass'
         execute "normal o".funcname."( "

--- a/test/signatures.vim
+++ b/test/signatures.vim
@@ -97,7 +97,7 @@ describe 'signatures'
         let funcname = repeat('a', &columns - (30 + (&ruler ? 18 : 0)))
         put = 'def '.funcname.'(arg1, arg2, arg3, a, b, c):'
         put = '    pass'
-        execute "normal o".funcname."( "
+        execute "normal o\<BS>".funcname."( "
         Expect Signature() == "\n".funcname."(arg1, …)"
 
         exe 'normal sarg1, '
@@ -112,7 +112,7 @@ describe 'signatures'
         g/^/d
         put = 'def '.funcname.'('.repeat('b', 20).', arg2):'
         put = '    pass'
-        execute "normal o".funcname."( "
+        execute "normal o\<BS>".funcname."( "
         Expect Signature() == "\n".funcname."(…)"
     end
 


### PR DESCRIPTION
This will allow us to get coverage via its Python subprocess then.

Includes #862 for setting `VSPEC_VIM`.