### PR TITLE
Fix displaying of error information with shortmess+=F

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ build/venv: | build
 	virtualenv -p python3.6 $@
 
 build/venv/bin/vint: | build/venv
-	$|/bin/pip install vim-vint==0.3.19
+	$|/bin/pip install -q vim-vint==0.3.19
 
 build/venv/bin/flake8: | build/venv
-	$|/bin/pip install flake8==3.5.0
+	$|/bin/pip install -q flake8==3.5.0
 
 vint: build/venv/bin/vint
 	build/venv/bin/vint after autoload ftplugin plugin


### PR DESCRIPTION
When being initialized via ftplugin `set shortmess+=F` (default in
Neovim by now) causes the additional information (the full traceback) to
be silenced.

This patch uses `:unsilent` to always display it.

Ref: https://github.com/neovim/neovim/issues/8675