### PR TITLE
goto: handle missing module_path better

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -315,6 +315,9 @@ def goto(mode="goto"):
             else:
                 echo_highlight("Builtin modules cannot be displayed (%s)."
                                % d.desc_with_module)
+        elif d.line is None and d.column is None:
+            echo_highlight("Cannot display (%s): no line/column."
+                           % d.desc_with_module)
         else:
             using_tagstack = int(vim_eval('g:jedi#use_tag_stack')) == 1
             if (d.module_path or '') != vim.current.buffer.name:


### PR DESCRIPTION
This handles using "goto" on "import vim".

I guess Jedi finds the internal "vim" module, but it has no source.

Neovim:

        print(inspect.getfile(vim))
      File "/usr/lib/python3.7/inspect.py", line 666, in getfile
        type(object).__name__))
    TypeError: module, class, method, function, traceback, frame, or code object was expected, got LegacyVim

Vim:

        print(inspect.getfile(vim))
      File "/usr/lib/python3.7/inspect.py", line 647, in getfile
        raise TypeError('{!r} is a built-in module'.format(object))
    TypeError: <module 'vim' (built-in)> is a built-in module