### PR TITLE
.coveragerc: concurrency = greenlet

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 branch = 1
+# Used by/for neovim-python-client.
+concurrency = greenlet
 
 [report]
 include = pythonx/jedi_*.py,test/*


### PR DESCRIPTION
Fixes https://github.com/neovim/python-client/issues/354