### PR TITLE
Fixes incorrect documentation

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -51,5 +51,6 @@ Bagrat Aznauryan (@n9code)
 Tomoyuki Kashiro (@kashiro)
 Tommy Allen (@tweekmonster)
 Mingliang (@Aulddays)
+Brian Mego (@brianmego)
 
 @something are github user names.

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -439,10 +439,10 @@ Default: 500
 
 You can make jedi-vim open a new tab if you use the "go to", "show
 definition", or "related names" commands. When you leave this at the default
-(0), they open in the current buffer instead.
+(0), they open in the current window instead.
 
 Options: 0 or 1
-Default: 0 (Command output is put in a new tab)
+Default: 0 (Command output reuses current window)
 
 ------------------------------------------------------------------------------
 6.9. `g:jedi#squelch_py_warning`        *g:jedi#squelch_py_warning*


### PR DESCRIPTION
Looks like this was introduced in 439e50e9 (2015-06-21). Apparently didn't bother anyone for 3 years, but might as well fix it!