### PR TITLE
add g:jedi#virtualenv_path to specify virtualenv

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -34,6 +34,7 @@ let s:default_settings = {
     \ 'popup_select_first': 1,
     \ 'quickfix_window_height': 10,
     \ 'force_py_version': "'auto'",
+    \ 'virtualenv_path': "''",
     \ 'smart_auto_mappings': 0,
     \ 'use_tag_stack': 1
 \ }

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -163,9 +163,22 @@ current_environment = (None, None)
 def get_environment(use_cache=True):
     global current_environment
 
+    vim_virtualenv_path = vim_eval("g:jedi#virtualenv_path")
     vim_force_python_version = vim_eval("g:jedi#force_py_version")
-    if use_cache and vim_force_python_version == current_environment[0]:
+
+    if use_cache and vim_force_python_version == current_environment[0] and vim_virtualenv_path == current_environment[0]:
         return current_environment[1]
+
+    if vim_virtualenv_path:
+        try:
+            environment = jedi.api.environment.create_environment(vim_virtualenv_path)
+        except jedi.InvalidPythonEnvironment as exc:
+            environment = jedi.api.environment.get_cached_default_environment()
+            echo_highlight(
+                "virutalenv_path=%s is invalid python environment." % (
+                    vim_virtualenv_path))
+        current_environment = (vim_virtualenv_path, environment)
+        return environment
 
     environment = None
     if vim_force_python_version == "auto":

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -166,7 +166,7 @@ def get_environment(use_cache=True):
     vim_virtualenv_path = vim_eval("g:jedi#virtualenv_path")
     vim_force_python_version = vim_eval("g:jedi#force_py_version")
 
-    if use_cache and vim_force_python_version == current_environment[0] and vim_virtualenv_path == current_environment[0]:
+    if use_cache and vim_force_python_version == current_environment[0] or vim_virtualenv_path == current_environment[0]:
         return current_environment[1]
 
     if vim_virtualenv_path:


### PR DESCRIPTION
Hello.

I added `g:jedi#vritualenv_path` to specify the virtual environment like `$VIRTUAL_ENV`, but this will work even after Jedi is started.

Would you please merge if you think this feature is good.

The following script is my usage.

```vim
" set the pipenv's environment for completion when open .py file
function! s:setPipenvPath()
  let pipenv_dir = expand('%:p:h')
  if !filereadable(l:pipenv_dir . '/Pipfile')
    return
  endif

  let venv_path = trim(system(printf("sh -c 'cd %s; pipenv --venv'", pipenv_dir)))
  let g:jedi#virtualenv_path = venv_path
endfunction

autocmd FileType python :call s:addPipenvPath()
```