### PR TITLE
doc: add example to disable all default maps

### DIFF
--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -24,7 +24,7 @@ Contents                                *jedi-vim-contents*
     5.1. Start completion               |g:jedi#completions_command|
     5.2. Go to definition               |g:jedi#goto_command|
     5.3. Go to assignment               |g:jedi#goto_assignments_command|
-    5.4  Go to definition (deprecated)  |g:jedi#goto_definitions_command|
+    5.4  Go to stub definition          |g:jedi#goto_stubs_command|
     5.5. Show documentation             |g:jedi#documentation_command|
     5.6. Rename variables               |g:jedi#rename_command|
     5.7. Show name usages               |g:jedi#usages_command|
@@ -214,6 +214,15 @@ a mapping yourself by calling a function: >
 
 Note: You can set commands to '', which means that they are empty and not
 assigned. It's an easy way to "disable" functionality of jedi-vim.
+To disable all default mappings use: >
+
+    let g:jedi#completions_command = ''
+    let g:jedi#goto_command = ''
+    let g:jedi#goto_assignments_command = ''
+    let g:jedi#goto_stubs_command = ''
+    let g:jedi#documentation_command = ''
+    let g:jedi#rename_command = ''
+    let g:jedi#usages_command = ''
 
 ------------------------------------------------------------------------------
 5.1. `g:jedi#completions_command`       *g:jedi#completions_command*
@@ -274,12 +283,9 @@ This function finds the first definition of the function/class under the
 cursor. It produces an error if the definition is not in a Python file.
 
 ------------------------------------------------------------------------------
-5.4. `g:jedi#goto_definitions_command`  *g:jedi#goto_definitions_command*
-Function: `jedi#goto_definitions()`
-Default: -                              Go to original definition
-
-NOTE: Deprecated. Use |g:jedi#goto_command| / |jedi#goto()| instead, which
-currently uses this internally.
+5.4. `g:jedi#goto_stubs_command`  *g:jedi#goto_stubs_command*
+Function: `jedi#goto_stubs_command()`
+Default: <leader>s                              Go to stubs definition
 
 ------------------------------------------------------------------------------
 5.5. `g:jedi#documentation_command`     *g:jedi#documentation_command*


### PR DESCRIPTION
Also removes section for deprecated `goto_definitions_command`.

Ref: https://github.com/davidhalter/jedi-vim/issues/213
Closes https://github.com/davidhalter/jedi-vim/pull/943