### PR TITLE
Fix invalidating cache with `jedi#show_call_signatures`

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -581,15 +581,16 @@ function! jedi#show_call_signatures() abort
 
     " Caching.  On the same line only.
     if line == s:show_call_signatures_last[0]
-        " Check if the number of commas and parenthesis before or after the
+        " Check if the number of special signs before or after the
         " cursor has not changed since the last call, which means that the
         " argument position was not changed and we can skip repainting.
         let prevcol = s:show_call_signatures_last[1]
         let prevline = s:show_call_signatures_last[2]
-        if substitute(curline[:col-2], '[^,()]', '', 'g')
-                    \ == substitute(prevline[:prevcol-2], '[^,()]', '', 'g')
-                    \ && substitute(curline[(col-2):], '[^,()]', '', 'g')
-                    \ == substitute(prevline[(prevcol-2):], '[^,()]', '', 'g')
+        let no_special = '[^,()=]'
+        if substitute(curline[:col-2], no_special, '', 'g')
+                    \ == substitute(prevline[:prevcol-2], no_special, '', 'g')
+                    \ && substitute(curline[(col-2):], no_special, '', 'g')
+                    \ == substitute(prevline[(prevcol-2):], no_special, '', 'g')
             let reload_signatures = 0
         endif
     endif

--- a/test/vspec/signatures.vim
+++ b/test/vspec/signatures.vim
@@ -53,9 +53,9 @@ describe 'signatures'
         doautocmd CursorHoldI
         Expect getline(1) =~# '\V\^?!?jedi=0, ?!?     (*values: object, *_*sep: Text=...*_*'
         " Move left to "=" - hightlights first argument ("values").
-        " NOTE: it is arguable that maybe "sep=..." should be highlight still,
-        "       but this tests for the cache to be "busted", and that fresh
-        "       results are retrieved from Jedi.
+        " NOTE: it is arguable that maybe "sep=..." should be highlighted
+        "       still, but this tests for the cache to be "busted", and that
+        "       fresh results are retrieved from Jedi.
         noautocmd normal h
         doautocmd CursorHoldI
         Expect getline(1) =~# '\V\^?!?jedi=0, ?!?     (*_**values: object*_*, sep: Text=...,'

--- a/test/vspec/signatures.vim
+++ b/test/vspec/signatures.vim
@@ -45,6 +45,9 @@ describe 'signatures'
     end
 
     it 'highlights correct argument'
+        if !has('python3')
+          SKIP 'py2: no signatures with print()'
+        endif
         noautocmd normal o
         doautocmd CursorHoldI
         noautocmd normal iprint(42, sep="X", )

--- a/test/vspec/signatures.vim
+++ b/test/vspec/signatures.vim
@@ -44,6 +44,23 @@ describe 'signatures'
         Expect getline(1) == '?!?jedi=0, ?!?            (*_*f: Callable*_*) ?!?jedi?!?'
     end
 
+    it 'highlights correct argument'
+        noautocmd normal o
+        doautocmd CursorHoldI
+        noautocmd normal iprint(42, sep="X", )
+        " Move to "=" - hightlights "sep=...".
+        noautocmd normal 5h
+        doautocmd CursorHoldI
+        Expect getline(1) =~# '\V\^?!?jedi=0, ?!?     (*values: object, *_*sep: Text=...*_*'
+        " Move left to "=" - hightlights first argument ("values").
+        " NOTE: it is arguable that maybe "sep=..." should be highlight still,
+        "       but this tests for the cache to be "busted", and that fresh
+        "       results are retrieved from Jedi.
+        noautocmd normal h
+        doautocmd CursorHoldI
+        Expect getline(1) =~# '\V\^?!?jedi=0, ?!?     (*_**values: object*_*, sep: Text=...,'
+    end
+
     it 'no signature'
         exe 'normal ostr '
         Python jedi_vim.show_call_signatures()


### PR DESCRIPTION
Without this it would not redraw properly when moving left within `print(…)` - see the test.