### PR TITLE
Add a funding button to github

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [davidhalter]


### PR DESCRIPTION
I have been accepted into the Github sponsorship program. I feel like you @blueyed could do that as well, so we could have both our names there.

If you don't like adding the button there, I'm fine with just leaving it out. I have it up on the Jedi repository.

In general I just want to try if this works and if there is going to be income generated through the button.

I don't think there will be a lot of money, so it probably doesn't even make sense to share it at this point. But if it happens to be more than a 200? dollars a month we should probably talk about it.