### PR TITLE
minor: rewrite/expand show_documentation

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -726,9 +726,17 @@ def show_documentation():
     if not definitions:
         echo_highlight('No documentation found for that.')
         vim.command('return')
-    else:
-        docs = ['Docstring for %s\n%s\n%s' % (d.desc_with_module, '=' * 40, d.docstring())
-                if d.docstring() else '|No Docstring for %s|' % d for d in definitions]
+        return
+
+    docs = []
+    for d in definitions:
+        doc = d.docstring()
+        if doc:
+            title = 'Docstring for %s' % d.desc_with_module
+            underline = '=' * len(title)
+            docs.append('%s\n%s\n%s' % (title, underline, doc))
+        else:
+            docs.append('|No Docstring for %s|' % d)
         text = ('\n' + '-' * 79 + '\n').join(docs)
         vim.command('let l:doc = %s' % repr(PythonToVimStr(text)))
         vim.command('let l:doc_lines = %s' % len(text.split('\n')))

--- a/test/vspec/documentation.vim
+++ b/test/vspec/documentation.vim
@@ -15,7 +15,16 @@ describe 'documentation docstrings'
         normal GK
         Expect bufname('%') == "__doc__"
         Expect &filetype == 'rst'
-        let content = join(getline(1,'$'), "\n")
+        let header = getline(1, 2)
+        PythonJedi vim.vars["is_py2"] = sys.version_info[0] == 2
+        if g:is_py2
+            Expect header[0] == "Docstring for __builtin__:class ImportError"
+            Expect header[1] == "==========================================="
+        else
+            Expect header[0] == "Docstring for builtins:class ImportError"
+            Expect header[1] == "========================================"
+        endif
+        let content = join(getline(3, '$'), "\n")
         Expect stridx(content, "Import can't find module") > 0
         normal K
         Expect bufname('%') == ''


### PR DESCRIPTION
The documentation test fails with newer Jedi, this is for investigating it.

```
________________ test_integration[test/vspec/documentation.vim] ________________
test/vspec/documentation.vim failed:
"__doc__" [New File]
# ImportError(*args, name: Optional[str]=..., path: Optional[str]=...)
not ok 1 - documentation docstrings simple
# Expected stridx(content, "Import can't find module") > 0 at line 11
#       Actual value: -1
#     Expected value: 0
5 buffers wiped out
ok 2 - documentation docstrings no documentation
1..2
```

TODO:

- [x] failure on py27

      test/vspec/documentation.vim failed:
      not found in 'runtimepath': "ftdetect/*.vim"
      not ok 1 - documentation docstrings simple
      # Expected header[0] == "Docstring for builtins:class ImportError" at line 7
      #       Actual value: "Docstring for __builtin__:class ImportError"
      #     Expected value: "Docstring for builtins:class ImportError"
      5 buffers wiped out
      ok 2 - documentation docstrings no documentation
      1..2
