### PR TITLE
show_call_signatures: doc, default to 2 without 'conceal'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,8 +182,10 @@ and usually saves one keypress.
 
 Jedi displays function call signatures in insert mode in real-time, highlighting
 the current argument. The call signatures can be displayed as a pop-up in the
-buffer (set to 1, the default), which has the advantage of being easier to refer
-to, or in Vim's command line aligned with the function call (set to 2), which
+buffer (set to 1 by default (with the conceal feature), 2 otherwise),
+which has the advantage of being easier to refer to (but is a hack with
+many drawbacks since it changes the buffer's contents),
+or in Vim's command line aligned with the function call (set to 2), which
 can improve the integrity of Vim's undo history.
 
 .. code-block:: vim

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -27,7 +27,7 @@ let s:default_settings = {
     \ 'completions_enabled': 1,
     \ 'popup_on_dot': 'g:jedi#completions_enabled',
     \ 'documentation_command': "'K'",
-    \ 'show_call_signatures': 1,
+    \ 'show_call_signatures': has('conceal') ? 1 : 2,
     \ 'show_call_signatures_delay': 500,
     \ 'call_signature_escape': "'?!?'",
     \ 'auto_close_doc': 1,

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -32,7 +32,7 @@ if g:jedi#auto_initialization
         execute 'nnoremap <silent> <buffer>'.g:jedi#documentation_command.' :call jedi#show_documentation()<CR>'
     endif
 
-    if g:jedi#show_call_signatures > 0 && has('conceal')
+    if g:jedi#show_call_signatures > 0
         call jedi#configure_call_signatures()
     endif
 


### PR DESCRIPTION
It basically allows to give a warning when '1' is used / set explicitly, and
the 'conceal' feature is not available.

Also defaulting to '2' (cmdline mode) then seems better than not using
it.

This is just some minor clean up before
https://github.com/davidhalter/jedi-vim/pull/652.