### PR TITLE
Fix jedi#add_goto_window: use :copen to go to the qf window always

### DIFF
--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -479,31 +479,23 @@ endfunction
 function! jedi#add_goto_window(for_usages, len) abort
     let height = min([a:len, g:jedi#quickfix_window_height])
 
-    " Using :cwindow allows to stay in the current window in case it is opened
-    " already.
-    let win_count = winnr('$')
-    execute 'belowright cwindow '.height
-    let qfwin_was_opened = winnr('$') > win_count
+    " Use :copen to go to the window always - the user should select an entry.
+    execute 'belowright copen '.height
 
-    if qfwin_was_opened
-        if &filetype !=# 'qf'
-            echoerr 'jedi-vim: unexpected ft with current window, please report!'
-        endif
-        if g:jedi#use_tabs_not_buffers == 1
-            noremap <buffer> <CR> :call jedi#goto_window_on_enter()<CR>
-        endif
-
-        augroup jedi_goto_window
-            if a:for_usages
-                autocmd BufWinLeave <buffer> call jedi#clear_usages()
-            else
-                autocmd WinLeave <buffer> q  " automatically leave, if an option is chosen
-            endif
-        augroup END
-    elseif a:for_usages && !s:supports_buffer_usages
-        " Init current window.
-        call jedi#_show_usages_in_win()
+    if &filetype !=# 'qf'
+        echoerr printf('jedi-vim: unexpected ft with current window (%s), please report!', &filetype)
     endif
+    if g:jedi#use_tabs_not_buffers == 1
+        noremap <buffer> <CR> :call jedi#goto_window_on_enter()<CR>
+    endif
+
+    augroup jedi_goto_window
+        if a:for_usages
+            autocmd BufWinLeave <buffer> call jedi#clear_usages()
+        else
+            autocmd WinLeave <buffer> q  " automatically leave, if an option is chosen
+        endif
+    augroup END
 
     if a:for_usages && !has('nvim')
         if s:supports_buffer_usages

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -470,12 +470,12 @@ def show_goto_multi_results(definitions, mode):
             and VimCompat.can_update_current_qflist_for_context(qf_context)):
         # Same list, only adjust title/selected entry.
         VimCompat.setqflist_title(qf_title)
+        vim_command('%dcc' % select_entry)
     else:
         VimCompat.setqflist(lst, title=qf_title, context=qf_context)
         for_usages = mode == "usages"
         vim_eval('jedi#add_goto_window(%d, %d)' % (for_usages, len(lst)))
-
-    vim_command('%d' % select_entry)
+        vim_command('%d' % select_entry)
 
 
 def _same_definitions(a, b):


### PR DESCRIPTION
Without this it would not go there with an already open qf window, and
would go to an unexpected buffer line instead of selecting the entry.

This is a follow-up to b689409, where it was decided that it should
always require the user to select an entry.

An exception is when the same usages are used again: then it will select
the nearest/current entry only (via ":cc").