### PR TITLE
show_goto_multi_results: handle `full_name=None`

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -460,7 +460,10 @@ def show_goto_multi_results(definitions, mode):
     # Build qflist title.
     qf_title = mode
     if current_def is not None:
-        qf_title += ": " + current_def.full_name
+        if current_def.full_name:
+            qf_title += ": " + current_def.full_name
+        else:
+            qf_title += ": " + str(current_def)
         select_entry = current_idx
     else:
         select_entry = 0


### PR DESCRIPTION
Seen with `<Definition name='key', description='param key'>` (using
usages on an function argument) [1].

1: https://github.com/pytest-dev/py/blob/2b6bd2925/py/_vendored_packages/iniconfig.py#L32-L33