### PR TITLE
Make use native popup windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(dir $(BUILD_VIRTUAL_ENV)):
 	mkdir -p $@
 
 $(BUILD_VIRTUAL_ENV): | $(dir $(BUILD_VIRTUAL_ENV))
-	python -m venv $@
+	python3 -m venv $@
 
 $(BUILD_VIRTUAL_ENV)/bin/vint: | $(BUILD_VIRTUAL_ENV)
 	$|/bin/python -m pip install vim-vint==0.3.21

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -29,6 +29,7 @@ let s:default_settings = {
     \ 'documentation_command': "'K'",
     \ 'show_call_signatures': has('popupwin') && has('textprop') ? 3 : has('conceal') ? 1 : 2,
     \ 'show_call_signatures_delay': 500,
+    \ 'show_call_signatures_wrap': has('linebreak'),
     \ 'call_signature_escape': "'?!?'",
     \ 'auto_close_doc': 1,
     \ 'max_doc_height': 30,

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -27,7 +27,7 @@ let s:default_settings = {
     \ 'completions_enabled': 1,
     \ 'popup_on_dot': 'g:jedi#completions_enabled',
     \ 'documentation_command': "'K'",
-    \ 'show_call_signatures': has('conceal') ? 1 : 2,
+    \ 'show_call_signatures': has('popupwin') && has('textprop') ? 3 : has('conceal') ? 1 : 2,
     \ 'show_call_signatures_delay': 500,
     \ 'call_signature_escape': "'?!?'",
     \ 'auto_close_doc': 1,

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -79,17 +79,18 @@ By leveraging this library, jedi-vim adds the following capabilities to Vim:
 
 First of all, jedi-vim requires Vim to be compiled with the `+python3` option.
 
-It is best if you have VIM >= 7.3, compiled with the `+conceal` option. With
-older versions, you will probably not see the parameter recommendation list
-for functions after typing the open bracket. Some platforms (including OS X
-releases) do not ship a VIM with `+conceal`. You can check if your VIM has the
-feature with >
+It is best if you have Vim >= 8.2, compiled with the `+popupwin` and
+`+textprop` options. Vim >= 7.3 with the `+conceal` option turned on will also
+work. In older versions, you will probably not see the parameter
+recommendation list for functions after typing the open bracket. Some
+platforms (including OS X releases) do not ship a VIM with `+conceal`. You can
+check if your VIM has the feature with >
 
-    :ver
+    :version
 
-and look for "`+conceal`" (as opposed to "`-conceal`") or >
+and look for "`+popupwin`", "`+textprop`" or "`+conceal`", or you can type >
 
-    :echo has('conceal')
+    :echo has('popupwin') && has('textprop') || has('conceal')
 
 which will report 0 (not included) or 1 (included). If your VIM lacks this
 feature and you would like function parameter completion, you will need to
@@ -398,11 +399,15 @@ Default: 1 (Automatically close preview window upon leaving insert mode)
 
 Jedi-vim can display a small window detailing the arguments of the currently
 completed function and highlighting the currently selected argument. This can
-be disabled by setting this option to 0. Setting this option to 2 shows call
+be disabled by setting this option to 0. If your Vim supports |popup-window|
+mechanism, Jedi will try it first which corresponds to the number 3.
+Otherwise, the plugin will try to simulate floating windows by means a special
+|syntax-highlighting|. Setting this option to 2 will force Jedi to show call
 signatures in the command line instead of a popup window.
 
-Options: 0, 1, or 2
-Default: 1 (Show call signatures window)
+Options: 0, 1, 2, or 3
+Default: 3 (Show call signatures window, however exact behaviour depends on
+            available features)
 
 Note: 'showmode' must be disabled for command line call signatures to be
 visible.

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -77,7 +77,7 @@ By leveraging this library, jedi-vim adds the following capabilities to Vim:
 ------------------------------------------------------------------------------
 2.0. Requirements                       *jedi-vim-installation-requirements*
 
-First of all, jedi-vim requires Vim to be compiled with the `+python` option.
+First of all, jedi-vim requires Vim to be compiled with the `+python3` option.
 
 It is best if you have VIM >= 7.3, compiled with the `+conceal` option. With
 older versions, you will probably not see the parameter recommendation list

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -37,14 +37,15 @@ Contents                                *jedi-vim-contents*
     6.5. auto_close_doc                 |g:jedi#auto_close_doc|
     6.6. show_call_signatures           |g:jedi#show_call_signatures|
     6.7. show_call_signatures_delay     |g:jedi#show_call_signatures_delay|
-    6.8. use_tabs_not_buffers           |g:jedi#use_tabs_not_buffers|
-    6.9. squelch_py_warning             |g:jedi#squelch_py_warning|
-    6.10. completions_enabled           |g:jedi#completions_enabled|
-    6.11. use_splits_not_buffers        |g:jedi#use_splits_not_buffers|
-    6.12. force_py_version              |g:jedi#force_py_version|
-    6.13. smart_auto_mappings           |g:jedi#smart_auto_mappings|
-    6.14. use_tag_stack                 |g:jedi#use_tag_stack|
-    6.15. environment_path              |g:jedi#environment_path|
+    6.8. show_call_signatures_wrap      |g:jedi#show_call_signatures_wrap|
+    6.9. use_tabs_not_buffers           |g:jedi#use_tabs_not_buffers|
+    6.10. squelch_py_warning            |g:jedi#squelch_py_warning|
+    6.11. completions_enabled           |g:jedi#completions_enabled|
+    6.12. use_splits_not_buffers        |g:jedi#use_splits_not_buffers|
+    6.13. force_py_version              |g:jedi#force_py_version|
+    6.14. smart_auto_mappings           |g:jedi#smart_auto_mappings|
+    6.15. use_tag_stack                 |g:jedi#use_tag_stack|
+    6.16. environment_path              |g:jedi#environment_path|
 7. Testing                              |jedi-vim-testing|
 8. Contributing                         |jedi-vim-contributing|
 9. License                              |jedi-vim-license|
@@ -429,7 +430,17 @@ Options: delay in milliseconds
 Default: 500
 
 ------------------------------------------------------------------------------
-6.8. `g:jedi#use_tabs_not_buffers`      *g:jedi#use_tabs_not_buffers*
+6.8. `g:jedi#show_call_signatures_wrap`     *g:jedi#show_call_signatures_wrap*
+
+Wrap long call signatures when they do not fit single line. The option has
+effect only inside native |popup-window|. The `+linebreak` feature is
+highly recommended for full working.
+
+Options: 0 or 1
+Default: 1 (Do wrapping if `+linebreak` feature is available)
+
+------------------------------------------------------------------------------
+6.9. `g:jedi#use_tabs_not_buffers`               *g:jedi#use_tabs_not_buffers*
 
 You can make jedi-vim open a new tab if you use the "go to", "show
 definition", or "related names" commands. When you leave this at the default
@@ -439,7 +450,7 @@ Options: 0 or 1
 Default: 0 (Command output reuses current window)
 
 ------------------------------------------------------------------------------
-6.9. `g:jedi#squelch_py_warning`        *g:jedi#squelch_py_warning*
+6.10. `g:jedi#squelch_py_warning`                  *g:jedi#squelch_py_warning*
 
 When Vim has not been compiled with +python, jedi-vim shows a warning to that
 effect and aborts loading itself. Set this to 1 to suppress that warning.
@@ -448,7 +459,7 @@ Options: 0 or 1
 Default: 0 (Warning is shown)
 
 ------------------------------------------------------------------------------
-6.10. `g:jedi#completions_enabled`      *g:jedi#completions_enabled*
+6.11. `g:jedi#completions_enabled`                *g:jedi#completions_enabled*
 
 If you don't want Jedi completion, but all the other features, you can disable
 it in favor of another completion engine (that probably also uses Jedi, like
@@ -458,7 +469,7 @@ Options: 0 or 1
 Default: 1
 
 ------------------------------------------------------------------------------
-6.11. `g:jedi#use_splits_not_buffers`   *g:jedi#use_splits_not_buffers*
+6.12. `g:jedi#use_splits_not_buffers`          *g:jedi#use_splits_not_buffers*
 
 If you want to open new split for "go to", you could set this option to the
 direction which you want to open a split with.
@@ -472,7 +483,7 @@ means that if the window is big enough it will be split vertically but if it is
 small a horizontal split happens.
 
 ------------------------------------------------------------------------------
-6.12. `g:jedi#force_py_version`                *g:jedi#force_py_version*
+6.13. `g:jedi#force_py_version`                      *g:jedi#force_py_version*
 
 If you have installed multiple Python versions, you can force the Python
 version that is going to be used.
@@ -489,7 +500,7 @@ This variable can be changed during runtime.
 Options: 2, 2.7, 3, 3.5, 3.6, ...
 Default: "auto"
 ------------------------------------------------------------------------------
-6.13. `g:jedi#smart_auto_mappings`                  *g:jedi#smart_auto_mappings*
+6.14. `g:jedi#smart_auto_mappings`                *g:jedi#smart_auto_mappings*
 
 When you start typing `from module.name<space>` jedi-vim automatically
 can add the "import" statement and trigger the autocompletion popup.
@@ -502,7 +513,7 @@ Options: 0 or 1
 Default: 0 (disabled by default)
 
 ------------------------------------------------------------------------------
-6.14. `g:jedi#use_tag_stack`                    *g:jedi#use_tag_stack*
+6.15. `g:jedi#use_tag_stack`                            *g:jedi#use_tag_stack*
 
 Write results of |jedi#goto| to a temporary file and use the |:tjump| command
 to enable full |tagstack| functionality. Use of the tag stack allows
@@ -513,7 +524,7 @@ Options: 0 or 1
 Default: 1 (enabled by default)
 
 ------------------------------------------------------------------------------
-6.15. `g:jedi#environment_path`                *g:jedi#environment_path*
+6.16. `g:jedi#environment_path`                      *g:jedi#environment_path*
 
 To use a specific virtualenv or a specific Python version it is possible to
 set an interpreter.

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -1019,13 +1019,15 @@ def popup_call_signatures(signatures):
     else:
         if b"jediSignatureAncor" not in VimCompat.call("prop_type_list"):
             VimCompat.call("prop_type_add", "jediSignatureAncor", {})
+        wrap_signatures = int(vim_eval("g:jedi#show_call_signatures_wrap"))
         _signatures_winid = VimCompat.call("popup_create", text,
                                            {"pos": "botleft",
                                             "posinvert": False,
                                             "highlight": "jediFunction",
                                             "mask": mask,
+                                            "wrap": bool(wrap_signatures),
                                             "textprop": "jediSignatureAncor"})
-        if VimCompat.has("linebreak"):
+        if wrap_signatures and VimCompat.has("linebreak"):
             VimCompat.call("setwinvar", _signatures_winid, "&linebreak", True)
             VimCompat.call("setwinvar", _signatures_winid, "&breakindent", True)
             # Continue wrapped lines right under left bracket.


### PR DESCRIPTION
This pull request offers to switch to native popup windows fully available since Vim 8.2. This solution will fix overlapping with other plugins which rely on buffer content. For example, [vim-gitgutter][1] is triggered by Jedi and marks lines above current one as modified due to invisible `?!?` stuff.

At the moment, the new implementation is not completed. It does not highlight selected parameter yet. If the idea makes interested, I will add full support to re-implement existing behavior.

 [1]: https://github.com/airblade/vim-gitgutter