### PR TITLE
Use helper function relpath() instead of os.path.relpath()

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -53,5 +53,6 @@ Tommy Allen (@tweekmonster)
 Mingliang (@Aulddays)
 Brian Mego (@brianmego)
 Stevan Milic (@stevanmilic) <stevan.milic@yahoo.com>
+Konstantin Glukhov (@Konstantin-Glukhov)
 
 @something are github user names.

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -1112,7 +1112,7 @@ def set_buffer(path: Optional[Path], options='', using_tagstack=False):
     if path in (vim.current.buffer.name, os.path.abspath(vim.current.buffer.name)):
         return True
 
-    path = os.path.relpath(path)
+    path = relpath(path)
     # options are what you can to edit the edit options
     if int(vim_eval('g:jedi#use_tabs_not_buffers')) == 1:
         _tabnew(path, options)


### PR DESCRIPTION
Use helper function relpath() instead of os.path.relpath()
to address issue #1044 ("path is on mount %r, start on mount %r" exception thrown
on Windows if Python and jedi-vim are installed on different drives)