### PR TITLE
The buffer-local variable `b:jedi_environment_path`

### DIFF
--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -45,6 +45,7 @@ Contents                                *jedi-vim-contents*
     6.13. smart_auto_mappings           |g:jedi#smart_auto_mappings|
     6.14. use_tag_stack                 |g:jedi#use_tag_stack|
     6.15. environment_path              |g:jedi#environment_path|
+                                        |b:jedi_environment_path|
     6.16. added_sys_path                |g:jedi#added_sys_path|
 7. Testing                              |jedi-vim-testing|
 8. Contributing                         |jedi-vim-contributing|
@@ -510,6 +511,7 @@ Default: 1 (enabled by default)
 
 ------------------------------------------------------------------------------
 6.15. `g:jedi#environment_path`                *g:jedi#environment_path*
+                                               *b:jedi_environment_path*
 
 To use a specific virtualenv or a specific Python version it is possible to
 set an interpreter.
@@ -517,6 +519,10 @@ set an interpreter.
 Both setting the directory and setting a project is working.
 
 Examples: "/usr/bin/python3.9", "venv", "../venv", "../venv/bin/python"
+
+The buffer-local variable `b:jedi_environment_path` can be used to override the
+global variable `g:jedi#environment_path`.
+
 Default: "auto"
 
 ------------------------------------------------------------------------------

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -218,7 +218,11 @@ _current_project_cache = None, None
 
 
 def get_project():
-    vim_environment_path = vim_eval("b:jedi_environment_path")
+    try:
+        vim_environment_path = vim_eval("b:jedi_environment_path")
+    except VimError:
+        vim_environment_path = ""
+
     if vim_environment_path in ("", None):
         vim_environment_path = vim_eval("g:jedi#environment_path")
     vim_project_path = vim_eval("g:jedi#project_path")

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -218,7 +218,9 @@ _current_project_cache = None, None
 
 
 def get_project():
-    vim_environment_path = vim_eval("g:jedi#environment_path")
+    vim_environment_path = vim_eval("b:jedi_environment_path")
+    if vim_environment_path in ("", None):
+        vim_environment_path = vim_eval("g:jedi#environment_path")
     vim_project_path = vim_eval("g:jedi#project_path")
     vim_added_sys_path = vim_eval("g:jedi#added_sys_path")
 


### PR DESCRIPTION
The buffer-local variable `b:jedi_environment_path` was added to jedi-vim to allow the user to override the global variable `g:jedi#environment_path` in the current buffer (useful to set a different virtualenv or Python version in the current buffer).