### PR TITLE
doc: Add hint about python 2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,10 +230,10 @@ Finally, if you don't want completion, but all the other features, use:
 FAQ
 ===
 
-I want to use Jedi with Python 2 Environment, but it's not listed in "Known environments"
------------------------------------------------------------------------------------------
+I want to use Jedi with a Python 2 Environment, but it's not listed under "Known environments"
+----------------------------------------------------------------------------------------------
 
-Starting from version 0.18 jedi droped the support of python 2.
+Starting with version 0.18.0 Jedi dropped support for Python 2.
 
 
 I don't want the docstring window to popup during completion

--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,12 @@ Finally, if you don't want completion, but all the other features, use:
 FAQ
 ===
 
+I want to use Jedi with Python 2 Environment, but it's not listed in "Known environments"
+-----------------------------------------------------------------------------------------
+
+Starting from version 0.18 jedi droped the support of python 2.
+
+
 I don't want the docstring window to popup during completion
 ------------------------------------------------------------
 


### PR DESCRIPTION
I searched for half an hour, why in :checkhealth of nvim, python 2 virtual environment is not shown, until I realized, that py2 is not supported by jedi itself.

So I think it's a good idea to mention in Readme that python 2 is not supported anymore. Maybe saves someones time.