### PR TITLE
Fix added_sys_path default setting

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -55,5 +55,6 @@ Brian Mego (@brianmego)
 Stevan Milic (@stevanmilic) <stevan.milic@yahoo.com>
 Konstantin Glukhov (@Konstantin-Glukhov)
 Seungchan An (@SeungChan92) <dev.issea1015@gmail.com>
+Thomas Blauth (@ThomasBlauth) <thomas.blauth@protonmail.com>
 
 @something are github user names.

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -36,7 +36,7 @@ let s:default_settings = {
     \ 'quickfix_window_height': 10,
     \ 'force_py_version': "'auto'",
     \ 'environment_path': "'auto'",
-    \ 'added_sys_path': "'[]'",
+    \ 'added_sys_path': '[]',
     \ 'project_path': "'auto'",
     \ 'smart_auto_mappings': 0,
     \ 'use_tag_stack': 1


### PR DESCRIPTION
I think I found a small bug in the default settings. The default setting for `added_sys_path` is sting quoted twice which leads to the value of `g:jedi#added_sys_path` beeing the string `"[]"` instead of an empty list.

Executing `python3 print(jedi_vim.get_project().added_sys_path)` returns `['[', ']']` instead of an empty list.

A results, for example, is that `:checkhealth` crashes when `g:jedi#added_sys_path` is actually set.

```
:let g:jedi#added_sys_path = ["../test"]

:checkhealth

 health#jedi#check
========================================================================
  - ERROR: Failed to run healthcheck for "jedi" plugin. Exception:
    function health#check[21]..health#jedi#check[2]..jedi#debug_info, line 64
    Vim(if):E691: Can only compare List with List
```


I'm not too familiar with vimscript, I hope my assumtions are actually true and not a misunderstanding on my part!