### PR TITLE
get_project: simplify getting b:jedi_environment_path override

### DIFF
--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -218,13 +218,9 @@ _current_project_cache = None, None
 
 
 def get_project():
-    try:
-        vim_environment_path = vim_eval("b:jedi_environment_path")
-    except VimError:
-        vim_environment_path = ""
-
-    if vim_environment_path in ("", None):
-        vim_environment_path = vim_eval("g:jedi#environment_path")
+    vim_environment_path = vim_eval(
+        "get(b:, 'jedi_environment_path', g:jedi#environment_path)"
+    )
     vim_project_path = vim_eval("g:jedi#project_path")
     vim_added_sys_path = vim_eval("g:jedi#added_sys_path")
 


### PR DESCRIPTION
- the common case is having an exception here (with no buffer setting),
  which results in the exception handler always
- vim_eval has overhead, especially with Neovim, so the less calls the
  better

This patch changes it to query the `b:` dict, using the (always
set/initialized) global setting as the default.

Ref: #1059 /cc @jamescherti (just for information)