### PR TITLE
Add option to enable/disable case insensitive completion

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -56,5 +56,6 @@ Stevan Milic (@stevanmilic) <stevan.milic@yahoo.com>
 Konstantin Glukhov (@Konstantin-Glukhov)
 Seungchan An (@SeungChan92) <dev.issea1015@gmail.com>
 Thomas Blauth (@ThomasBlauth) <thomas.blauth@protonmail.com>
+James Cherti (@jamescherti)
 
 @something are github user names.

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -39,6 +39,7 @@ let s:default_settings = {
     \ 'added_sys_path': '[]',
     \ 'project_path': "'auto'",
     \ 'smart_auto_mappings': 0,
+    \ 'case_insensitive_completion': 1,
     \ 'use_tag_stack': 1
 \ }
 

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -47,6 +47,8 @@ Contents                                *jedi-vim-contents*
     6.15. environment_path              |g:jedi#environment_path|
                                         |b:jedi_environment_path|
     6.16. added_sys_path                |g:jedi#added_sys_path|
+    6.17. case_insensitive_completion   |g:jedi#case_insensitive_completion|
+                                        |b:jedi_case_insensitive_completion|
 7. Testing                              |jedi-vim-testing|
 8. Contributing                         |jedi-vim-contributing|
 9. License                              |jedi-vim-license|
@@ -532,6 +534,18 @@ To add extra sys_path.
 
 Examples: ["../site-packages"]
 Default: []
+
+------------------------------------------------------------------------------
+6.17. `g:jedi#case_insensitive_completion` *g:jedi#case_insensitive_completion*
+                                           *b:jedi_case_insensitive_completion*
+
+0 to disable case insensitive completion.
+1 to enable case insensitive completion (default).
+
+The buffer-local variable `b:jedi_case_insensitive_completion` can be used to
+override the global variable `g:jedi#case_insensitive_completion`.
+
+Default: 1
 
 ==============================================================================
 7. Testing                              *jedi-vim-testing*

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -321,6 +321,10 @@ def get_pos(column=None):
 @_check_jedi_availability(show_error=False)
 @catch_and_print_exceptions
 def completions():
+    jedi.settings.case_insensitive_completion = \
+        bool(int(vim_eval("get(b:, 'jedi_case_insensitive_completion', "
+                          "g:jedi#case_insensitive_completion)")))
+
     row, column = vim.current.window.cursor
     # Clear call signatures in the buffer so they aren't seen by the completer.
     # Call signatures in the command line can stay.


### PR DESCRIPTION
This pull request adds an option to enable/disable case insensitive completion (the Jedi setting: `jedi.settings.case_insensitive_completion`).

It adds the following options to jedi-vim:
- Global option: `g:jedi#case_insensitive_completion`
- Buffer-local option: `b:jedi_case_insensitive_completion`

Values:
- 0 to disable case insensitive completion.
- 1 to enable case insensitive completion (default).