### PR TITLE
Add a keyboard mapping to rename  variables/functions/classes without deleting the word under the cursor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,7 @@ get more information. If you set them to ``""``, they are not assigned.
     let g:jedi#usages_command = "<leader>n"
     let g:jedi#completions_command = "<C-Space>"
     let g:jedi#rename_command = "<leader>r"
+    let g:jedi#rename_command_keep_name = "<leader>R"
 
 An example for setting up your project:
 

--- a/autoload/jedi.vim
+++ b/autoload/jedi.vim
@@ -24,6 +24,7 @@ let s:default_settings = {
     \ 'call_signatures_command': "'<leader>n'",
     \ 'usages_command': "'<leader>n'",
     \ 'rename_command': "'<leader>r'",
+    \ 'rename_command_keep_name': "'<leader>R'",
     \ 'completions_enabled': 1,
     \ 'popup_on_dot': 'g:jedi#completions_enabled',
     \ 'documentation_command': "'K'",
@@ -368,6 +369,14 @@ endfunction
 
 function! jedi#rename_visual(...) abort
     python3 jedi_vim.rename_visual()
+endfunction
+
+function! jedi#rename_keep_name(...) abort
+    python3 jedi_vim.rename(delete_word=False)
+endfunction
+
+function! jedi#rename_visual_keep_name(...) abort
+    python3 jedi_vim.rename_visual(use_selected_text_as_prompt_answer=True)
 endfunction
 
 function! jedi#completions(findstart, base) abort

--- a/doc/jedi-vim.txt
+++ b/doc/jedi-vim.txt
@@ -27,8 +27,9 @@ Contents                                *jedi-vim-contents*
     5.4  Go to stub                     |g:jedi#goto_stubs_command|
     5.5. Show documentation             |g:jedi#documentation_command|
     5.6. Rename variables               |g:jedi#rename_command|
-    5.7. Show name usages               |g:jedi#usages_command|
-    5.8. Open module by name            |:Pyimport|
+    5.7. Rename variables (Reuse name)  |g:jedi#rename_command_keep_name|
+    5.8. Show name usages               |g:jedi#usages_command|
+    5.9. Open module by name            |:Pyimport|
 6. Configuration                        |jedi-vim-configuration|
     6.1. auto_initialization            |g:jedi#auto_initialization|
     6.2. auto_vim_configuration         |g:jedi#auto_vim_configuration|
@@ -307,7 +308,19 @@ with the new one. The number of performed renames is displayed in the command
 line.
 
 ------------------------------------------------------------------------------
-5.7. `g:jedi#usages_command`            *g:jedi#usages_command*
+5.7. `g:jedi#rename_command_keep_name`        *g:jedi#rename_command_keep_name*
+Function: `jedi#rename()`
+Default: <leader>R                                            Rename variables
+                  (This key mapping does not delete the word under the cursor)
+
+Jedi-vim keeps the word currently under the cursor, moves the cursor to the end
+of the word, and puts Vim in insert mode, where the user is expected to enter
+the new variable name. Upon leaving insert mode, Jedi-vim then renames all
+occurrences of the old variable name with the new one. The number of performed
+renames is displayed in the command line.
+
+------------------------------------------------------------------------------
+5.8. `g:jedi#usages_command`            *g:jedi#usages_command*
 Function: `jedi#usages()`
 Default: <leader>n                      Show usages of a name.
 
@@ -315,7 +328,7 @@ The quickfix window is populated with a list of all names which point to the
 definition of the name under the cursor.
 
 ------------------------------------------------------------------------------
-5.8. Open module by name                *:Pyimport*
+5.9. Open module by name                *:Pyimport*
 Function: `jedi#py_import(args)`
 Default: :Pyimport                      e.g. `:Pyimport os` shows os.py in VIM.
 

--- a/ftplugin/python/jedi.vim
+++ b/ftplugin/python/jedi.vim
@@ -27,6 +27,10 @@ if g:jedi#auto_initialization
         execute 'nnoremap <buffer> '.g:jedi#rename_command.' :call jedi#rename()<CR>'
         execute 'vnoremap <buffer> '.g:jedi#rename_command.' :call jedi#rename_visual()<CR>'
     endif
+    if len(g:jedi#rename_command_keep_name)
+        execute 'nnoremap <buffer> '.g:jedi#rename_command_keep_name.' :call jedi#rename_keep_name()<CR>'
+        execute 'vnoremap <buffer> '.g:jedi#rename_command_keep_name.' :call jedi#rename_visual_keep_name()<CR>'
+    endif
     " documentation/pydoc
     if len(g:jedi#documentation_command)
         execute 'nnoremap <silent> <buffer>'.g:jedi#documentation_command.' :call jedi#show_documentation()<CR>'


### PR DESCRIPTION
This pull request adds the key mapping `<Leader>R` (upper case R) to rename variables/functions/classes without deleting the word under the cursor:
- **`<Leader>R` in Normal mode:** Jedi-vim keeps the word under the cursor, moves the cursor to the end of the word, and puts Vim in insert mode, where the user is expected to enter the new variable name.
- **`<Leader>R` in Visual mode:** Use the selected text as the default answer to the prompt.

**Bug fix:** This pull request also adds the support for `set selection=exclusive` to the function `rename_visual()`