### PR TITLE
Remove mention of Python 2.7 support in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,9 +73,9 @@ Installation
 
 Requirements
 ------------
-You need a VIM version that was compiled with Python 2.7 or later
-(``+python`` or ``+python3``).  You can check this from within VIM using
-``:python3 import sys; print(sys.version)`` (use ``:python`` for Python 2).
+You need a VIM version that was compiled with Python 3 or later
+(``+python3``).  You can check this from within VIM using
+``:python3 import sys; print(sys.version)``.
 
 Manual installation
 -------------------


### PR DESCRIPTION
Hi there! I was reading the installation instructions and requirements and saw that Python 2.7 was required, so I went ahead and installed jedi-vim. However, upon starting vim next, I learned that Python 2.7 was no longer supported. This PR just removes Python 2.7 from the requirements so that the requirements are clearer/up-to-date. If I'm missing something and Python 2.7 is still required, please feel free to close this PR.