### PR TITLE
Add Neovim Installation Requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,9 +73,15 @@ Installation
 
 Requirements
 ------------
-You need a VIM version that was compiled with Python 3 or later
+- **Vim**: You need a VIM version that was compiled with Python 3 or later
 (``+python3``).  You can check this from within VIM using
 ``:python3 import sys; print(sys.version)``.
+
+- **Neovim**: You need a python environment with ``pynvim`` installed:
+``pip install pynvim``
+
+then check your environment is correctly setup from within Neovim using
+``:checkhealth provider.python``
 
 Manual installation
 -------------------


### PR DESCRIPTION
Add information for Neovim that the python package `pynvim` is needed for a working python environment inside `nvim`.

Also so provide command needed to check that the environment setup is functional.