### PR TITLE
Saving initial column offset for completions in case a chain of

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -57,5 +57,6 @@ Konstantin Glukhov (@Konstantin-Glukhov)
 Seungchan An (@SeungChan92) <dev.issea1015@gmail.com>
 Thomas Blauth (@ThomasBlauth) <thomas.blauth@protonmail.com>
 James Cherti (@jamescherti)
+Pablo Gimenez Pizarro (@pablogipi) <pablogipi@gmail.com>
 
 @something are github user names.

--- a/pythonx/jedi_vim.py
+++ b/pythonx/jedi_vim.py
@@ -342,9 +342,12 @@ def completions():
             if not re.match(r'[\w\d]', char):
                 break
             count += 1
+        # Save initial correct calculated offset, in case a chain of completions is called using o flag in complete
+        vim.command("let b:omni_offset=%i" % (column - count))
         vim.command('return %i' % (column - count))
     else:
         base = vim.eval('a:base')
+        column = vim.current.buffer.vars["omni_offset"]
         source = ''
         for i, line in enumerate(vim.current.buffer):
             # enter this path again, otherwise source would be incomplete


### PR DESCRIPTION
The new **o** flag for complete allows to query completions from omni func after the next or previous word completion:
This is not working at the moment in jedi-vim because in completions() the tool first ask for current row and column to check
if it needs to find start, then calls it again, but if it is a chained completion lookup, like when adding the o flag this second callback to get current row and columns returns a wrong value for column because the first completion looks like is moving the cursor.
So here I'm saving the original column values in a buffer variable for later use and then all works as expected, the omnifunc works and adds it's results to the next/prev word search.